### PR TITLE
[chore] Add .editorconfig to make files look better in Github

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false
+indent_size = 2
+
+[*.{yml, yaml, raml, yml.dist, feature, toml, tf}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
### Description
Go likes tabs for whatever reason, and Github displays them as 8 spaces by default, which is pretty hard to read. Adding `.editorconfig` file that should fix this problem.

### Tests
No tests.