### PR TITLE
[feat] Add "sweeper" to clean up folder resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #-----------------------------------------------------------------------------------------------------------------------
 # Testing
 #-----------------------------------------------------------------------------------------------------------------------
-.PHONY: test-unit test-acc test-acc-record test-acc-replay
+.PHONY: test-unit test-acc test-acc-record test-acc-replay test-acc-sweep
 
 test-unit: ## Run unit tests. To run a specific test, pass the FILTER var. Usage `make test-unit FILTER="TestAccResourceServer"`
 	${call print, "Running unit tests"}
@@ -48,3 +48,11 @@ test-acc-replay:
 		-run "$(FILTER)" \
 		-timeout 30m \
 		./internal/provider/...
+
+test-acc-sweep: ## Remove all resources created by acceptance tests. Don't forget to set RETOOL_HOST, RETOOL_SCHEME and RETOOL_ACCESS_TOKEN env vars.
+	${call print, "Removing all resources created by acceptance tests"}
+	@TF_ACC=1  \
+		go test \
+		./internal/provider/... \
+		-sweep=default \
+		-v

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ make test-acc
 Note that the acceptance tests will create, modify and delete resources in the Retool org.
 You can run specific tests by setting `FILTER` env var as well.
 
+If acceptance tests fail and leave some undeleted resources on the Retool instance, you can delete them using "sweepers":
+```
+make test-acc-sweep
+```
+
 ### Recording and replaying HTTP requests for acceptance tests
 It's hard to run acceptance tests on CI hitting a live Retool instance. Instead, we have a way to record and store HTTP responses during acceptance test run, then use canned responses to avoid hitting Retool instance.
 Recorded responses are stored in `test/data/recordings/<test name>.yaml` files.

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1,6 +1,7 @@
 package acctest
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
 
 	"github.com/tryretool/terraform-provider-retool/internal/provider"
+	"github.com/tryretool/terraform-provider-retool/internal/sdk/api"
 )
 
 const (
@@ -38,6 +40,33 @@ func Test(t *testing.T, testCase resource.TestCase) {
 
 	testCase.ProtoV6ProviderFactories = providerTestFactories
 	resource.Test(t, testCase)
+}
+
+func SweeperClient() (*api.APIClient, error) {
+	host := os.Getenv("RETOOL_HOST")
+	if host == "" {
+		return nil, fmt.Errorf("RETOOL_HOST must be set")
+	}
+	scheme := os.Getenv("RETOOL_SCHEME")
+	if scheme == "" {
+		scheme = "https"
+	}
+	accessToken := os.Getenv("RETOOL_ACCESS_TOKEN")
+	if accessToken == "" {
+		return nil, fmt.Errorf("RETOOL_ACCESS_TOKEN must be set")
+	}
+
+	clientConfig := api.NewConfiguration()
+	clientConfig.Host = host
+	clientConfig.Scheme = scheme
+	clientConfig.Servers = api.ServerConfigurations{
+		api.ServerConfiguration{
+			URL: "/api/v2",
+		},
+	}
+
+	clientConfig.AddDefaultHeader("Authorization", "Bearer "+accessToken)
+	return api.NewAPIClient(clientConfig), nil
 }
 
 func httpRecordingsAreEnabled() bool {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -5,8 +5,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
 
 func TestNewProvider(t *testing.T) {
 	version := "1.0.0"


### PR DESCRIPTION
### Description
Acceptance tests create some folders in Retool instance. If they hard fail, folders are left undeleted, meaning the next test run will fail as well. This change adds command to cleanup the folders (and other resources in the future) created by the tests.

### Tests
Created `tf-acc-test` folder, ran `make test-acc-sweep`, made sure the folder was deleted.