### PR TITLE
[chore] Ignore unknown properties when parsing Retool API responses

### DIFF
--- a/internal/sdk/api/model__access_requests__access_request_id__get_200_response.go
+++ b/internal/sdk/api/model__access_requests__access_request_id__get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type AccessRequestsAccessRequestIdGet200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data AccessRequestsGet200ResponseDataInner `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AccessRequestsAccessRequestIdGet200Response AccessRequestsAccessRequestIdGet200Response
@@ -107,6 +107,11 @@ func (o AccessRequestsAccessRequestIdGet200Response) ToMap() (map[string]interfa
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *AccessRequestsAccessRequestIdGet200Response) UnmarshalJSON(data []byte)
 
 	varAccessRequestsAccessRequestIdGet200Response := _AccessRequestsAccessRequestIdGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAccessRequestsAccessRequestIdGet200Response)
+	err = json.Unmarshal(data, &varAccessRequestsAccessRequestIdGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AccessRequestsAccessRequestIdGet200Response(varAccessRequestsAccessRequestIdGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__access_requests__access_request_id__patch_200_response.go
+++ b/internal/sdk/api/model__access_requests__access_request_id__patch_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type AccessRequestsAccessRequestIdPatch200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data AccessRequestsGet200ResponseDataInner `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AccessRequestsAccessRequestIdPatch200Response AccessRequestsAccessRequestIdPatch200Response
@@ -107,6 +107,11 @@ func (o AccessRequestsAccessRequestIdPatch200Response) ToMap() (map[string]inter
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *AccessRequestsAccessRequestIdPatch200Response) UnmarshalJSON(data []byt
 
 	varAccessRequestsAccessRequestIdPatch200Response := _AccessRequestsAccessRequestIdPatch200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAccessRequestsAccessRequestIdPatch200Response)
+	err = json.Unmarshal(data, &varAccessRequestsAccessRequestIdPatch200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AccessRequestsAccessRequestIdPatch200Response(varAccessRequestsAccessRequestIdPatch200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__access_requests_get_200_response.go
+++ b/internal/sdk/api/model__access_requests_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type AccessRequestsGet200Response struct {
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AccessRequestsGet200Response AccessRequestsGet200Response
@@ -194,6 +194,11 @@ func (o AccessRequestsGet200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *AccessRequestsGet200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varAccessRequestsGet200Response := _AccessRequestsGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAccessRequestsGet200Response)
+	err = json.Unmarshal(data, &varAccessRequestsGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AccessRequestsGet200Response(varAccessRequestsGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__access_requests_get_200_response_data_inner.go
+++ b/internal/sdk/api/model__access_requests_get_200_response_data_inner.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type AccessRequestsGet200ResponseDataInner struct {
 	LegacyId float32 `json:"legacy_id"`
 	RequestingEmail string `json:"requesting_email"`
 	UpdatedById NullableString `json:"updated_by_id"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AccessRequestsGet200ResponseDataInner AccessRequestsGet200ResponseDataInner
@@ -189,6 +189,11 @@ func (o AccessRequestsGet200ResponseDataInner) ToMap() (map[string]interface{}, 
 	toSerialize["legacy_id"] = o.LegacyId
 	toSerialize["requesting_email"] = o.RequestingEmail
 	toSerialize["updated_by_id"] = o.UpdatedById.Get()
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -220,15 +225,24 @@ func (o *AccessRequestsGet200ResponseDataInner) UnmarshalJSON(data []byte) (err 
 
 	varAccessRequestsGet200ResponseDataInner := _AccessRequestsGet200ResponseDataInner{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAccessRequestsGet200ResponseDataInner)
+	err = json.Unmarshal(data, &varAccessRequestsGet200ResponseDataInner)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AccessRequestsGet200ResponseDataInner(varAccessRequestsGet200ResponseDataInner)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "requesting_email")
+		delete(additionalProperties, "updated_by_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__app_themes__id__get_200_response.go
+++ b/internal/sdk/api/model__app_themes__id__get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type AppThemesIdGet200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data AppThemesIdGet200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AppThemesIdGet200Response AppThemesIdGet200Response
@@ -107,6 +107,11 @@ func (o AppThemesIdGet200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *AppThemesIdGet200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varAppThemesIdGet200Response := _AppThemesIdGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAppThemesIdGet200Response)
+	err = json.Unmarshal(data, &varAppThemesIdGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AppThemesIdGet200Response(varAppThemesIdGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__app_themes__id__get_200_response_data.go
+++ b/internal/sdk/api/model__app_themes__id__get_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -27,6 +26,7 @@ type AppThemesIdGet200ResponseData struct {
 	Name string `json:"name"`
 	// The theme object.
 	Theme map[string]interface{} `json:"theme"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AppThemesIdGet200ResponseData AppThemesIdGet200ResponseData
@@ -162,6 +162,11 @@ func (o AppThemesIdGet200ResponseData) ToMap() (map[string]interface{}, error) {
 	toSerialize["legacy_id"] = o.LegacyId
 	toSerialize["name"] = o.Name
 	toSerialize["theme"] = o.Theme
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -192,15 +197,23 @@ func (o *AppThemesIdGet200ResponseData) UnmarshalJSON(data []byte) (err error) {
 
 	varAppThemesIdGet200ResponseData := _AppThemesIdGet200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAppThemesIdGet200ResponseData)
+	err = json.Unmarshal(data, &varAppThemesIdGet200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AppThemesIdGet200ResponseData(varAppThemesIdGet200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "theme")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__app_themes_put_200_response.go
+++ b/internal/sdk/api/model__app_themes_put_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type AppThemesPut200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data AppThemesPut200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AppThemesPut200Response AppThemesPut200Response
@@ -107,6 +107,11 @@ func (o AppThemesPut200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *AppThemesPut200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varAppThemesPut200Response := _AppThemesPut200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAppThemesPut200Response)
+	err = json.Unmarshal(data, &varAppThemesPut200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AppThemesPut200Response(varAppThemesPut200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__app_themes_put_200_response_data.go
+++ b/internal/sdk/api/model__app_themes_put_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -27,6 +26,7 @@ type AppThemesPut200ResponseData struct {
 	Name string `json:"name"`
 	// The theme object.
 	Theme map[string]interface{} `json:"theme"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AppThemesPut200ResponseData AppThemesPut200ResponseData
@@ -162,6 +162,11 @@ func (o AppThemesPut200ResponseData) ToMap() (map[string]interface{}, error) {
 	toSerialize["legacy_id"] = o.LegacyId
 	toSerialize["name"] = o.Name
 	toSerialize["theme"] = o.Theme
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -192,15 +197,23 @@ func (o *AppThemesPut200ResponseData) UnmarshalJSON(data []byte) (err error) {
 
 	varAppThemesPut200ResponseData := _AppThemesPut200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAppThemesPut200ResponseData)
+	err = json.Unmarshal(data, &varAppThemesPut200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AppThemesPut200ResponseData(varAppThemesPut200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "theme")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__app_themes_put_request.go
+++ b/internal/sdk/api/model__app_themes_put_request.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -27,6 +26,7 @@ type AppThemesPutRequest struct {
 	Name string `json:"name"`
 	// The theme object.
 	Theme map[string]interface{} `json:"theme"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AppThemesPutRequest AppThemesPutRequest
@@ -162,6 +162,11 @@ func (o AppThemesPutRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize["legacy_id"] = o.LegacyId
 	toSerialize["name"] = o.Name
 	toSerialize["theme"] = o.Theme
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -192,15 +197,23 @@ func (o *AppThemesPutRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varAppThemesPutRequest := _AppThemesPutRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAppThemesPutRequest)
+	err = json.Unmarshal(data, &varAppThemesPutRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AppThemesPutRequest(varAppThemesPutRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "theme")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__apps__app_id__get_200_response.go
+++ b/internal/sdk/api/model__apps__app_id__get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type AppsAppIdGet200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data AppsAppIdGet200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AppsAppIdGet200Response AppsAppIdGet200Response
@@ -107,6 +107,11 @@ func (o AppsAppIdGet200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *AppsAppIdGet200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varAppsAppIdGet200Response := _AppsAppIdGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAppsAppIdGet200Response)
+	err = json.Unmarshal(data, &varAppsAppIdGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AppsAppIdGet200Response(varAppsAppIdGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__apps__app_id__get_200_response_data.go
+++ b/internal/sdk/api/model__apps__app_id__get_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -39,6 +38,7 @@ type AppsAppIdGet200ResponseData struct {
 	IsModule bool `json:"is_module"`
 	// Whether the App is a mobile app
 	IsMobileApp bool `json:"is_mobile_app"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AppsAppIdGet200ResponseData AppsAppIdGet200ResponseData
@@ -308,6 +308,11 @@ func (o AppsAppIdGet200ResponseData) ToMap() (map[string]interface{}, error) {
 	toSerialize["shortlink"] = o.Shortlink.Get()
 	toSerialize["is_module"] = o.IsModule
 	toSerialize["is_mobile_app"] = o.IsMobileApp
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -343,15 +348,28 @@ func (o *AppsAppIdGet200ResponseData) UnmarshalJSON(data []byte) (err error) {
 
 	varAppsAppIdGet200ResponseData := _AppsAppIdGet200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAppsAppIdGet200ResponseData)
+	err = json.Unmarshal(data, &varAppsAppIdGet200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AppsAppIdGet200ResponseData(varAppsAppIdGet200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "folder_id")
+		delete(additionalProperties, "protected")
+		delete(additionalProperties, "synced")
+		delete(additionalProperties, "shortlink")
+		delete(additionalProperties, "is_module")
+		delete(additionalProperties, "is_mobile_app")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__apps_get_200_response.go
+++ b/internal/sdk/api/model__apps_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type AppsGet200Response struct {
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AppsGet200Response AppsGet200Response
@@ -194,6 +194,11 @@ func (o AppsGet200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *AppsGet200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varAppsGet200Response := _AppsGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAppsGet200Response)
+	err = json.Unmarshal(data, &varAppsGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AppsGet200Response(varAppsGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__configuration_variables_get_200_response.go
+++ b/internal/sdk/api/model__configuration_variables_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type ConfigurationVariablesGet200Response struct {
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ConfigurationVariablesGet200Response ConfigurationVariablesGet200Response
@@ -194,6 +194,11 @@ func (o ConfigurationVariablesGet200Response) ToMap() (map[string]interface{}, e
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *ConfigurationVariablesGet200Response) UnmarshalJSON(data []byte) (err e
 
 	varConfigurationVariablesGet200Response := _ConfigurationVariablesGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varConfigurationVariablesGet200Response)
+	err = json.Unmarshal(data, &varConfigurationVariablesGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ConfigurationVariablesGet200Response(varConfigurationVariablesGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__configuration_variables_get_200_response_data_inner.go
+++ b/internal/sdk/api/model__configuration_variables_get_200_response_data_inner.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -30,6 +29,7 @@ type ConfigurationVariablesGet200ResponseDataInner struct {
 	// Whether the configuration variable is a secret
 	Secret bool `json:"secret"`
 	Values []ConfigurationVariablesGet200ResponseDataInnerValuesInner `json:"values"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ConfigurationVariablesGet200ResponseDataInner ConfigurationVariablesGet200ResponseDataInner
@@ -200,6 +200,11 @@ func (o ConfigurationVariablesGet200ResponseDataInner) ToMap() (map[string]inter
 	}
 	toSerialize["secret"] = o.Secret
 	toSerialize["values"] = o.Values
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -230,15 +235,24 @@ func (o *ConfigurationVariablesGet200ResponseDataInner) UnmarshalJSON(data []byt
 
 	varConfigurationVariablesGet200ResponseDataInner := _ConfigurationVariablesGet200ResponseDataInner{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varConfigurationVariablesGet200ResponseDataInner)
+	err = json.Unmarshal(data, &varConfigurationVariablesGet200ResponseDataInner)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ConfigurationVariablesGet200ResponseDataInner(varConfigurationVariablesGet200ResponseDataInner)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "secret")
+		delete(additionalProperties, "values")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__configuration_variables_get_200_response_data_inner_values_inner.go
+++ b/internal/sdk/api/model__configuration_variables_get_200_response_data_inner_values_inner.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -25,6 +24,7 @@ type ConfigurationVariablesGet200ResponseDataInnerValuesInner struct {
 	EnvironmentId string `json:"environment_id"`
 	// The value of the configuration variable
 	Value string `json:"value"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ConfigurationVariablesGet200ResponseDataInnerValuesInner ConfigurationVariablesGet200ResponseDataInnerValuesInner
@@ -108,6 +108,11 @@ func (o ConfigurationVariablesGet200ResponseDataInnerValuesInner) ToMap() (map[s
 	toSerialize := map[string]interface{}{}
 	toSerialize["environment_id"] = o.EnvironmentId
 	toSerialize["value"] = o.Value
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -136,15 +141,21 @@ func (o *ConfigurationVariablesGet200ResponseDataInnerValuesInner) UnmarshalJSON
 
 	varConfigurationVariablesGet200ResponseDataInnerValuesInner := _ConfigurationVariablesGet200ResponseDataInnerValuesInner{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varConfigurationVariablesGet200ResponseDataInnerValuesInner)
+	err = json.Unmarshal(data, &varConfigurationVariablesGet200ResponseDataInnerValuesInner)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ConfigurationVariablesGet200ResponseDataInnerValuesInner(varConfigurationVariablesGet200ResponseDataInnerValuesInner)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "environment_id")
+		delete(additionalProperties, "value")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__configuration_variables_post_200_response.go
+++ b/internal/sdk/api/model__configuration_variables_post_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type ConfigurationVariablesPost200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data ConfigurationVariablesGet200ResponseDataInner `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ConfigurationVariablesPost200Response ConfigurationVariablesPost200Response
@@ -107,6 +107,11 @@ func (o ConfigurationVariablesPost200Response) ToMap() (map[string]interface{}, 
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *ConfigurationVariablesPost200Response) UnmarshalJSON(data []byte) (err 
 
 	varConfigurationVariablesPost200Response := _ConfigurationVariablesPost200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varConfigurationVariablesPost200Response)
+	err = json.Unmarshal(data, &varConfigurationVariablesPost200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ConfigurationVariablesPost200Response(varConfigurationVariablesPost200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__configuration_variables_post_request.go
+++ b/internal/sdk/api/model__configuration_variables_post_request.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -28,6 +27,7 @@ type ConfigurationVariablesPostRequest struct {
 	// Whether the configuration variable is a secret
 	Secret bool `json:"secret"`
 	Values []ConfigurationVariablesGet200ResponseDataInnerValuesInner `json:"values"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ConfigurationVariablesPostRequest ConfigurationVariablesPostRequest
@@ -172,6 +172,11 @@ func (o ConfigurationVariablesPostRequest) ToMap() (map[string]interface{}, erro
 	}
 	toSerialize["secret"] = o.Secret
 	toSerialize["values"] = o.Values
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -201,15 +206,23 @@ func (o *ConfigurationVariablesPostRequest) UnmarshalJSON(data []byte) (err erro
 
 	varConfigurationVariablesPostRequest := _ConfigurationVariablesPostRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varConfigurationVariablesPostRequest)
+	err = json.Unmarshal(data, &varConfigurationVariablesPostRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ConfigurationVariablesPostRequest(varConfigurationVariablesPostRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "secret")
+		delete(additionalProperties, "values")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__custom_component_libraries__library_id__get_200_response.go
+++ b/internal/sdk/api/model__custom_component_libraries__library_id__get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type CustomComponentLibrariesLibraryIdGet200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data CustomComponentLibrariesLibraryIdGet200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CustomComponentLibrariesLibraryIdGet200Response CustomComponentLibrariesLibraryIdGet200Response
@@ -107,6 +107,11 @@ func (o CustomComponentLibrariesLibraryIdGet200Response) ToMap() (map[string]int
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *CustomComponentLibrariesLibraryIdGet200Response) UnmarshalJSON(data []b
 
 	varCustomComponentLibrariesLibraryIdGet200Response := _CustomComponentLibrariesLibraryIdGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCustomComponentLibrariesLibraryIdGet200Response)
+	err = json.Unmarshal(data, &varCustomComponentLibrariesLibraryIdGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CustomComponentLibrariesLibraryIdGet200Response(varCustomComponentLibrariesLibraryIdGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__custom_component_libraries__library_id__get_200_response_data.go
+++ b/internal/sdk/api/model__custom_component_libraries__library_id__get_200_response_data.go
@@ -13,7 +13,6 @@ package api
 import (
 	"encoding/json"
 	"time"
-	"bytes"
 	"fmt"
 )
 
@@ -30,6 +29,7 @@ type CustomComponentLibrariesLibraryIdGet200ResponseData struct {
 	Label string `json:"label"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CustomComponentLibrariesLibraryIdGet200ResponseData CustomComponentLibrariesLibraryIdGet200ResponseData
@@ -219,6 +219,11 @@ func (o CustomComponentLibrariesLibraryIdGet200ResponseData) ToMap() (map[string
 	toSerialize["label"] = o.Label
 	toSerialize["created_at"] = o.CreatedAt
 	toSerialize["updated_at"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -251,15 +256,25 @@ func (o *CustomComponentLibrariesLibraryIdGet200ResponseData) UnmarshalJSON(data
 
 	varCustomComponentLibrariesLibraryIdGet200ResponseData := _CustomComponentLibrariesLibraryIdGet200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCustomComponentLibrariesLibraryIdGet200ResponseData)
+	err = json.Unmarshal(data, &varCustomComponentLibrariesLibraryIdGet200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CustomComponentLibrariesLibraryIdGet200ResponseData(varCustomComponentLibrariesLibraryIdGet200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "label")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__custom_component_libraries__library_id__revisions__revision_id__files_get_200_response.go
+++ b/internal/sdk/api/model__custom_component_libraries__library_id__revisions__revision_id__files_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type CustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200Response str
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200Response CustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200Response
@@ -194,6 +194,11 @@ func (o CustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200Response)
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *CustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200Response
 
 	varCustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200Response := _CustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200Response)
+	err = json.Unmarshal(data, &varCustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200Response(varCustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__custom_component_libraries__library_id__revisions__revision_id__files_get_200_response_data_inner.go
+++ b/internal/sdk/api/model__custom_component_libraries__library_id__revisions__revision_id__files_get_200_response_data_inner.go
@@ -13,7 +13,6 @@ package api
 import (
 	"encoding/json"
 	"time"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type CustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200ResponseData
 	FileContents string `json:"file_contents"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200ResponseDataInner CustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200ResponseDataInner
@@ -161,6 +161,11 @@ func (o CustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200ResponseD
 	toSerialize["file_contents"] = o.FileContents
 	toSerialize["created_at"] = o.CreatedAt
 	toSerialize["updated_at"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -191,15 +196,23 @@ func (o *CustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200Response
 
 	varCustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200ResponseDataInner := _CustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200ResponseDataInner{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200ResponseDataInner)
+	err = json.Unmarshal(data, &varCustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200ResponseDataInner)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200ResponseDataInner(varCustomComponentLibrariesLibraryIdRevisionsRevisionIdFilesGet200ResponseDataInner)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "filepath")
+		delete(additionalProperties, "file_contents")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__custom_component_libraries__library_id__revisions_get_200_response.go
+++ b/internal/sdk/api/model__custom_component_libraries__library_id__revisions_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type CustomComponentLibrariesLibraryIdRevisionsGet200Response struct {
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CustomComponentLibrariesLibraryIdRevisionsGet200Response CustomComponentLibrariesLibraryIdRevisionsGet200Response
@@ -194,6 +194,11 @@ func (o CustomComponentLibrariesLibraryIdRevisionsGet200Response) ToMap() (map[s
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *CustomComponentLibrariesLibraryIdRevisionsGet200Response) UnmarshalJSON
 
 	varCustomComponentLibrariesLibraryIdRevisionsGet200Response := _CustomComponentLibrariesLibraryIdRevisionsGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCustomComponentLibrariesLibraryIdRevisionsGet200Response)
+	err = json.Unmarshal(data, &varCustomComponentLibrariesLibraryIdRevisionsGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CustomComponentLibrariesLibraryIdRevisionsGet200Response(varCustomComponentLibrariesLibraryIdRevisionsGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__custom_component_libraries__library_id__revisions_get_200_response_data_inner.go
+++ b/internal/sdk/api/model__custom_component_libraries__library_id__revisions_get_200_response_data_inner.go
@@ -13,7 +13,6 @@ package api
 import (
 	"encoding/json"
 	"time"
-	"bytes"
 	"fmt"
 )
 
@@ -27,6 +26,7 @@ type CustomComponentLibrariesLibraryIdRevisionsGet200ResponseDataInner struct {
 	CustomComponentLibraryId string `json:"custom_component_library_id"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CustomComponentLibrariesLibraryIdRevisionsGet200ResponseDataInner CustomComponentLibrariesLibraryIdRevisionsGet200ResponseDataInner
@@ -188,6 +188,11 @@ func (o CustomComponentLibrariesLibraryIdRevisionsGet200ResponseDataInner) ToMap
 	toSerialize["custom_component_library_id"] = o.CustomComponentLibraryId
 	toSerialize["created_at"] = o.CreatedAt
 	toSerialize["updated_at"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -219,15 +224,24 @@ func (o *CustomComponentLibrariesLibraryIdRevisionsGet200ResponseDataInner) Unma
 
 	varCustomComponentLibrariesLibraryIdRevisionsGet200ResponseDataInner := _CustomComponentLibrariesLibraryIdRevisionsGet200ResponseDataInner{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCustomComponentLibrariesLibraryIdRevisionsGet200ResponseDataInner)
+	err = json.Unmarshal(data, &varCustomComponentLibrariesLibraryIdRevisionsGet200ResponseDataInner)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CustomComponentLibrariesLibraryIdRevisionsGet200ResponseDataInner(varCustomComponentLibrariesLibraryIdRevisionsGet200ResponseDataInner)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "version")
+		delete(additionalProperties, "custom_component_library_id")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__custom_component_libraries__library_id__revisions_post_200_response.go
+++ b/internal/sdk/api/model__custom_component_libraries__library_id__revisions_post_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type CustomComponentLibrariesLibraryIdRevisionsPost200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data CustomComponentLibrariesLibraryIdRevisionsGet200ResponseDataInner `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CustomComponentLibrariesLibraryIdRevisionsPost200Response CustomComponentLibrariesLibraryIdRevisionsPost200Response
@@ -107,6 +107,11 @@ func (o CustomComponentLibrariesLibraryIdRevisionsPost200Response) ToMap() (map[
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *CustomComponentLibrariesLibraryIdRevisionsPost200Response) UnmarshalJSO
 
 	varCustomComponentLibrariesLibraryIdRevisionsPost200Response := _CustomComponentLibrariesLibraryIdRevisionsPost200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCustomComponentLibrariesLibraryIdRevisionsPost200Response)
+	err = json.Unmarshal(data, &varCustomComponentLibrariesLibraryIdRevisionsPost200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CustomComponentLibrariesLibraryIdRevisionsPost200Response(varCustomComponentLibrariesLibraryIdRevisionsPost200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__custom_component_libraries_get_200_response.go
+++ b/internal/sdk/api/model__custom_component_libraries_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type CustomComponentLibrariesGet200Response struct {
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CustomComponentLibrariesGet200Response CustomComponentLibrariesGet200Response
@@ -194,6 +194,11 @@ func (o CustomComponentLibrariesGet200Response) ToMap() (map[string]interface{},
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *CustomComponentLibrariesGet200Response) UnmarshalJSON(data []byte) (err
 
 	varCustomComponentLibrariesGet200Response := _CustomComponentLibrariesGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCustomComponentLibrariesGet200Response)
+	err = json.Unmarshal(data, &varCustomComponentLibrariesGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CustomComponentLibrariesGet200Response(varCustomComponentLibrariesGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__custom_component_libraries_post_200_response.go
+++ b/internal/sdk/api/model__custom_component_libraries_post_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type CustomComponentLibrariesPost200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data CustomComponentLibrariesLibraryIdGet200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CustomComponentLibrariesPost200Response CustomComponentLibrariesPost200Response
@@ -107,6 +107,11 @@ func (o CustomComponentLibrariesPost200Response) ToMap() (map[string]interface{}
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *CustomComponentLibrariesPost200Response) UnmarshalJSON(data []byte) (er
 
 	varCustomComponentLibrariesPost200Response := _CustomComponentLibrariesPost200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCustomComponentLibrariesPost200Response)
+	err = json.Unmarshal(data, &varCustomComponentLibrariesPost200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CustomComponentLibrariesPost200Response(varCustomComponentLibrariesPost200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__custom_component_libraries_post_request.go
+++ b/internal/sdk/api/model__custom_component_libraries_post_request.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -28,6 +27,7 @@ type CustomComponentLibrariesPostRequest struct {
 	Description NullableString `json:"description"`
 	// How the library will be referred to in the Retool UI. Should be human readable.
 	Label string `json:"label"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CustomComponentLibrariesPostRequest CustomComponentLibrariesPostRequest
@@ -174,6 +174,11 @@ func (o CustomComponentLibrariesPostRequest) ToMap() (map[string]interface{}, er
 	toSerialize["name"] = o.Name
 	toSerialize["description"] = o.Description.Get()
 	toSerialize["label"] = o.Label
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -203,15 +208,23 @@ func (o *CustomComponentLibrariesPostRequest) UnmarshalJSON(data []byte) (err er
 
 	varCustomComponentLibrariesPostRequest := _CustomComponentLibrariesPostRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCustomComponentLibrariesPostRequest)
+	err = json.Unmarshal(data, &varCustomComponentLibrariesPostRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CustomComponentLibrariesPostRequest(varCustomComponentLibrariesPostRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "label")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__environments__environment_id__get_200_response.go
+++ b/internal/sdk/api/model__environments__environment_id__get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type EnvironmentsEnvironmentIdGet200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data EnvironmentsEnvironmentIdGet200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _EnvironmentsEnvironmentIdGet200Response EnvironmentsEnvironmentIdGet200Response
@@ -107,6 +107,11 @@ func (o EnvironmentsEnvironmentIdGet200Response) ToMap() (map[string]interface{}
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *EnvironmentsEnvironmentIdGet200Response) UnmarshalJSON(data []byte) (er
 
 	varEnvironmentsEnvironmentIdGet200Response := _EnvironmentsEnvironmentIdGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varEnvironmentsEnvironmentIdGet200Response)
+	err = json.Unmarshal(data, &varEnvironmentsEnvironmentIdGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = EnvironmentsEnvironmentIdGet200Response(varEnvironmentsEnvironmentIdGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__environments__environment_id__get_200_response_data.go
+++ b/internal/sdk/api/model__environments__environment_id__get_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -28,6 +27,7 @@ type EnvironmentsEnvironmentIdGet200ResponseData struct {
 	Default bool `json:"default"`
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _EnvironmentsEnvironmentIdGet200ResponseData EnvironmentsEnvironmentIdGet200ResponseData
@@ -243,6 +243,11 @@ func (o EnvironmentsEnvironmentIdGet200ResponseData) ToMap() (map[string]interfa
 	toSerialize["default"] = o.Default
 	toSerialize["created_at"] = o.CreatedAt
 	toSerialize["updated_at"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -276,15 +281,26 @@ func (o *EnvironmentsEnvironmentIdGet200ResponseData) UnmarshalJSON(data []byte)
 
 	varEnvironmentsEnvironmentIdGet200ResponseData := _EnvironmentsEnvironmentIdGet200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varEnvironmentsEnvironmentIdGet200ResponseData)
+	err = json.Unmarshal(data, &varEnvironmentsEnvironmentIdGet200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = EnvironmentsEnvironmentIdGet200ResponseData(varEnvironmentsEnvironmentIdGet200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "color")
+		delete(additionalProperties, "default")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__environments_get_200_response.go
+++ b/internal/sdk/api/model__environments_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type EnvironmentsGet200Response struct {
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _EnvironmentsGet200Response EnvironmentsGet200Response
@@ -194,6 +194,11 @@ func (o EnvironmentsGet200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *EnvironmentsGet200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varEnvironmentsGet200Response := _EnvironmentsGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varEnvironmentsGet200Response)
+	err = json.Unmarshal(data, &varEnvironmentsGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = EnvironmentsGet200Response(varEnvironmentsGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__folders__folder_id__get_200_response.go
+++ b/internal/sdk/api/model__folders__folder_id__get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type FoldersFolderIdGet200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data FoldersFolderIdGet200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FoldersFolderIdGet200Response FoldersFolderIdGet200Response
@@ -107,6 +107,11 @@ func (o FoldersFolderIdGet200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *FoldersFolderIdGet200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varFoldersFolderIdGet200Response := _FoldersFolderIdGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFoldersFolderIdGet200Response)
+	err = json.Unmarshal(data, &varFoldersFolderIdGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FoldersFolderIdGet200Response(varFoldersFolderIdGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__folders__folder_id__get_200_response_data.go
+++ b/internal/sdk/api/model__folders__folder_id__get_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -33,6 +32,7 @@ type FoldersFolderIdGet200ResponseData struct {
 	IsSystemFolder bool `json:"is_system_folder"`
 	// The type of the folder
 	FolderType string `json:"folder_type"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FoldersFolderIdGet200ResponseData FoldersFolderIdGet200ResponseData
@@ -239,6 +239,11 @@ func (o FoldersFolderIdGet200ResponseData) ToMap() (map[string]interface{}, erro
 	}
 	toSerialize["is_system_folder"] = o.IsSystemFolder
 	toSerialize["folder_type"] = o.FolderType
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -270,15 +275,25 @@ func (o *FoldersFolderIdGet200ResponseData) UnmarshalJSON(data []byte) (err erro
 
 	varFoldersFolderIdGet200ResponseData := _FoldersFolderIdGet200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFoldersFolderIdGet200ResponseData)
+	err = json.Unmarshal(data, &varFoldersFolderIdGet200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FoldersFolderIdGet200ResponseData(varFoldersFolderIdGet200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "parent_folder_id")
+		delete(additionalProperties, "is_system_folder")
+		delete(additionalProperties, "folder_type")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__folders_get_200_response.go
+++ b/internal/sdk/api/model__folders_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type FoldersGet200Response struct {
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FoldersGet200Response FoldersGet200Response
@@ -194,6 +194,11 @@ func (o FoldersGet200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *FoldersGet200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varFoldersGet200Response := _FoldersGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFoldersGet200Response)
+	err = json.Unmarshal(data, &varFoldersGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FoldersGet200Response(varFoldersGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__folders_get_200_response_data_inner.go
+++ b/internal/sdk/api/model__folders_get_200_response_data_inner.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -33,6 +32,7 @@ type FoldersGet200ResponseDataInner struct {
 	IsSystemFolder bool `json:"is_system_folder"`
 	// The type of the folder
 	FolderType string `json:"folder_type"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FoldersGet200ResponseDataInner FoldersGet200ResponseDataInner
@@ -239,6 +239,11 @@ func (o FoldersGet200ResponseDataInner) ToMap() (map[string]interface{}, error) 
 	}
 	toSerialize["is_system_folder"] = o.IsSystemFolder
 	toSerialize["folder_type"] = o.FolderType
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -270,15 +275,25 @@ func (o *FoldersGet200ResponseDataInner) UnmarshalJSON(data []byte) (err error) 
 
 	varFoldersGet200ResponseDataInner := _FoldersGet200ResponseDataInner{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFoldersGet200ResponseDataInner)
+	err = json.Unmarshal(data, &varFoldersGet200ResponseDataInner)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FoldersGet200ResponseDataInner(varFoldersGet200ResponseDataInner)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "parent_folder_id")
+		delete(additionalProperties, "is_system_folder")
+		delete(additionalProperties, "folder_type")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__folders_post_200_response.go
+++ b/internal/sdk/api/model__folders_post_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type FoldersPost200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data FoldersPost200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FoldersPost200Response FoldersPost200Response
@@ -107,6 +107,11 @@ func (o FoldersPost200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *FoldersPost200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varFoldersPost200Response := _FoldersPost200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFoldersPost200Response)
+	err = json.Unmarshal(data, &varFoldersPost200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FoldersPost200Response(varFoldersPost200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__folders_post_200_response_data.go
+++ b/internal/sdk/api/model__folders_post_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -33,6 +32,7 @@ type FoldersPost200ResponseData struct {
 	IsSystemFolder bool `json:"is_system_folder"`
 	// The type of the folder
 	FolderType string `json:"folder_type"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FoldersPost200ResponseData FoldersPost200ResponseData
@@ -239,6 +239,11 @@ func (o FoldersPost200ResponseData) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["is_system_folder"] = o.IsSystemFolder
 	toSerialize["folder_type"] = o.FolderType
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -270,15 +275,25 @@ func (o *FoldersPost200ResponseData) UnmarshalJSON(data []byte) (err error) {
 
 	varFoldersPost200ResponseData := _FoldersPost200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFoldersPost200ResponseData)
+	err = json.Unmarshal(data, &varFoldersPost200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FoldersPost200ResponseData(varFoldersPost200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "parent_folder_id")
+		delete(additionalProperties, "is_system_folder")
+		delete(additionalProperties, "folder_type")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__folders_post_409_response.go
+++ b/internal/sdk/api/model__folders_post_409_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -25,6 +24,7 @@ type FoldersPost409Response struct {
 	Success bool `json:"success"`
 	// Error message
 	Message string `json:"message"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FoldersPost409Response FoldersPost409Response
@@ -108,6 +108,11 @@ func (o FoldersPost409Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["message"] = o.Message
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -136,15 +141,21 @@ func (o *FoldersPost409Response) UnmarshalJSON(data []byte) (err error) {
 
 	varFoldersPost409Response := _FoldersPost409Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFoldersPost409Response)
+	err = json.Unmarshal(data, &varFoldersPost409Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FoldersPost409Response(varFoldersPost409Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "message")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__folders_post_request.go
+++ b/internal/sdk/api/model__folders_post_request.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -27,6 +26,7 @@ type FoldersPostRequest struct {
 	ParentFolderId NullableString `json:"parent_folder_id,omitempty"`
 	// The type of the folder.
 	FolderType string `json:"folder_type"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FoldersPostRequest FoldersPostRequest
@@ -155,6 +155,11 @@ func (o FoldersPostRequest) ToMap() (map[string]interface{}, error) {
 		toSerialize["parent_folder_id"] = o.ParentFolderId.Get()
 	}
 	toSerialize["folder_type"] = o.FolderType
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -183,15 +188,22 @@ func (o *FoldersPostRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varFoldersPostRequest := _FoldersPostRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFoldersPostRequest)
+	err = json.Unmarshal(data, &varFoldersPostRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FoldersPostRequest(varFoldersPostRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "parent_folder_id")
+		delete(additionalProperties, "folder_type")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__groups__group_id__get_200_response.go
+++ b/internal/sdk/api/model__groups__group_id__get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type GroupsGroupIdGet200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data GroupsGroupIdGet200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GroupsGroupIdGet200Response GroupsGroupIdGet200Response
@@ -107,6 +107,11 @@ func (o GroupsGroupIdGet200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *GroupsGroupIdGet200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varGroupsGroupIdGet200Response := _GroupsGroupIdGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGroupsGroupIdGet200Response)
+	err = json.Unmarshal(data, &varGroupsGroupIdGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GroupsGroupIdGet200Response(varGroupsGroupIdGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__groups__group_id__get_200_response_data.go
+++ b/internal/sdk/api/model__groups__group_id__get_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -49,6 +48,7 @@ type GroupsGroupIdGet200ResponseData struct {
 	AccountDetailsAccess bool `json:"account_details_access"`
 	// The app ID of the landing page
 	LandingPageAppId NullableString `json:"landing_page_app_id"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GroupsGroupIdGet200ResponseData GroupsGroupIdGet200ResponseData
@@ -450,6 +450,11 @@ func (o GroupsGroupIdGet200ResponseData) ToMap() (map[string]interface{}, error)
 	toSerialize["usage_analytics_access"] = o.UsageAnalyticsAccess
 	toSerialize["account_details_access"] = o.AccountDetailsAccess
 	toSerialize["landing_page_app_id"] = o.LandingPageAppId.Get()
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -490,15 +495,33 @@ func (o *GroupsGroupIdGet200ResponseData) UnmarshalJSON(data []byte) (err error)
 
 	varGroupsGroupIdGet200ResponseData := _GroupsGroupIdGet200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGroupsGroupIdGet200ResponseData)
+	err = json.Unmarshal(data, &varGroupsGroupIdGet200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GroupsGroupIdGet200ResponseData(varGroupsGroupIdGet200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "members")
+		delete(additionalProperties, "universal_app_access")
+		delete(additionalProperties, "universal_resource_access")
+		delete(additionalProperties, "universal_workflow_access")
+		delete(additionalProperties, "user_invites")
+		delete(additionalProperties, "user_list_access")
+		delete(additionalProperties, "audit_log_access")
+		delete(additionalProperties, "unpublished_release_access")
+		delete(additionalProperties, "usage_analytics_access")
+		delete(additionalProperties, "account_details_access")
+		delete(additionalProperties, "landing_page_app_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__groups__group_id__get_200_response_data_members_inner.go
+++ b/internal/sdk/api/model__groups__group_id__get_200_response_data_members_inner.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type GroupsGroupIdGet200ResponseDataMembersInner struct {
 	Email string `json:"email"`
 	// Whether the user is a group admin
 	IsGroupAdmin bool `json:"is_group_admin"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GroupsGroupIdGet200ResponseDataMembersInner GroupsGroupIdGet200ResponseDataMembersInner
@@ -137,6 +137,11 @@ func (o GroupsGroupIdGet200ResponseDataMembersInner) ToMap() (map[string]interfa
 	toSerialize["id"] = o.Id
 	toSerialize["email"] = o.Email
 	toSerialize["is_group_admin"] = o.IsGroupAdmin
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -166,15 +171,22 @@ func (o *GroupsGroupIdGet200ResponseDataMembersInner) UnmarshalJSON(data []byte)
 
 	varGroupsGroupIdGet200ResponseDataMembersInner := _GroupsGroupIdGet200ResponseDataMembersInner{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGroupsGroupIdGet200ResponseDataMembersInner)
+	err = json.Unmarshal(data, &varGroupsGroupIdGet200ResponseDataMembersInner)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GroupsGroupIdGet200ResponseDataMembersInner(varGroupsGroupIdGet200ResponseDataMembersInner)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "is_group_admin")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__groups__group_id__get_200_response_data_user_invites_inner.go
+++ b/internal/sdk/api/model__groups__group_id__get_200_response_data_user_invites_inner.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -32,6 +31,7 @@ type GroupsGroupIdGet200ResponseDataUserInvitesInner struct {
 	Metadata map[string]interface{} `json:"metadata"`
 	CreatedAt string `json:"created_at"`
 	InviteLink *string `json:"invite_link,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GroupsGroupIdGet200ResponseDataUserInvitesInner GroupsGroupIdGet200ResponseDataUserInvitesInner
@@ -368,6 +368,11 @@ func (o GroupsGroupIdGet200ResponseDataUserInvitesInner) ToMap() (map[string]int
 	if !IsNil(o.InviteLink) {
 		toSerialize["invite_link"] = o.InviteLink
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -404,15 +409,30 @@ func (o *GroupsGroupIdGet200ResponseDataUserInvitesInner) UnmarshalJSON(data []b
 
 	varGroupsGroupIdGet200ResponseDataUserInvitesInner := _GroupsGroupIdGet200ResponseDataUserInvitesInner{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGroupsGroupIdGet200ResponseDataUserInvitesInner)
+	err = json.Unmarshal(data, &varGroupsGroupIdGet200ResponseDataUserInvitesInner)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GroupsGroupIdGet200ResponseDataUserInvitesInner(varGroupsGroupIdGet200ResponseDataUserInvitesInner)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "invited_by")
+		delete(additionalProperties, "invited_email")
+		delete(additionalProperties, "expires_at")
+		delete(additionalProperties, "claimed_by")
+		delete(additionalProperties, "claimed_at")
+		delete(additionalProperties, "user_type")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "invite_link")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__groups__group_id__members_post_request.go
+++ b/internal/sdk/api/model__groups__group_id__members_post_request.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &GroupsGroupIdMembersPostRequest{}
 // GroupsGroupIdMembersPostRequest Users to add to the group
 type GroupsGroupIdMembersPostRequest struct {
 	Members []GroupsGroupIdPutRequestMembersInner `json:"members"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GroupsGroupIdMembersPostRequest GroupsGroupIdMembersPostRequest
@@ -79,6 +79,11 @@ func (o GroupsGroupIdMembersPostRequest) MarshalJSON() ([]byte, error) {
 func (o GroupsGroupIdMembersPostRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["members"] = o.Members
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *GroupsGroupIdMembersPostRequest) UnmarshalJSON(data []byte) (err error)
 
 	varGroupsGroupIdMembersPostRequest := _GroupsGroupIdMembersPostRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGroupsGroupIdMembersPostRequest)
+	err = json.Unmarshal(data, &varGroupsGroupIdMembersPostRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GroupsGroupIdMembersPostRequest(varGroupsGroupIdMembersPostRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "members")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__groups__group_id__put_200_response.go
+++ b/internal/sdk/api/model__groups__group_id__put_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type GroupsGroupIdPut200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data GroupsGroupIdPut200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GroupsGroupIdPut200Response GroupsGroupIdPut200Response
@@ -107,6 +107,11 @@ func (o GroupsGroupIdPut200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *GroupsGroupIdPut200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varGroupsGroupIdPut200Response := _GroupsGroupIdPut200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGroupsGroupIdPut200Response)
+	err = json.Unmarshal(data, &varGroupsGroupIdPut200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GroupsGroupIdPut200Response(varGroupsGroupIdPut200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__groups__group_id__put_200_response_data.go
+++ b/internal/sdk/api/model__groups__group_id__put_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -49,6 +48,7 @@ type GroupsGroupIdPut200ResponseData struct {
 	AccountDetailsAccess bool `json:"account_details_access"`
 	// The app ID of the landing page
 	LandingPageAppId NullableString `json:"landing_page_app_id"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GroupsGroupIdPut200ResponseData GroupsGroupIdPut200ResponseData
@@ -450,6 +450,11 @@ func (o GroupsGroupIdPut200ResponseData) ToMap() (map[string]interface{}, error)
 	toSerialize["usage_analytics_access"] = o.UsageAnalyticsAccess
 	toSerialize["account_details_access"] = o.AccountDetailsAccess
 	toSerialize["landing_page_app_id"] = o.LandingPageAppId.Get()
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -490,15 +495,33 @@ func (o *GroupsGroupIdPut200ResponseData) UnmarshalJSON(data []byte) (err error)
 
 	varGroupsGroupIdPut200ResponseData := _GroupsGroupIdPut200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGroupsGroupIdPut200ResponseData)
+	err = json.Unmarshal(data, &varGroupsGroupIdPut200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GroupsGroupIdPut200ResponseData(varGroupsGroupIdPut200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "members")
+		delete(additionalProperties, "universal_app_access")
+		delete(additionalProperties, "universal_resource_access")
+		delete(additionalProperties, "universal_workflow_access")
+		delete(additionalProperties, "user_invites")
+		delete(additionalProperties, "user_list_access")
+		delete(additionalProperties, "audit_log_access")
+		delete(additionalProperties, "unpublished_release_access")
+		delete(additionalProperties, "usage_analytics_access")
+		delete(additionalProperties, "account_details_access")
+		delete(additionalProperties, "landing_page_app_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__groups__group_id__put_request.go
+++ b/internal/sdk/api/model__groups__group_id__put_request.go
@@ -42,7 +42,10 @@ type GroupsGroupIdPutRequest struct {
 	AccountDetailsAccess *bool `json:"account_details_access,omitempty"`
 	// The app ID of the landing page
 	LandingPageAppId NullableString `json:"landing_page_app_id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _GroupsGroupIdPutRequest GroupsGroupIdPutRequest
 
 // NewGroupsGroupIdPutRequest instantiates a new GroupsGroupIdPutRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -501,7 +504,44 @@ func (o GroupsGroupIdPutRequest) ToMap() (map[string]interface{}, error) {
 	if o.LandingPageAppId.IsSet() {
 		toSerialize["landing_page_app_id"] = o.LandingPageAppId.Get()
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *GroupsGroupIdPutRequest) UnmarshalJSON(data []byte) (err error) {
+	varGroupsGroupIdPutRequest := _GroupsGroupIdPutRequest{}
+
+	err = json.Unmarshal(data, &varGroupsGroupIdPutRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = GroupsGroupIdPutRequest(varGroupsGroupIdPutRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "members")
+		delete(additionalProperties, "universal_app_access")
+		delete(additionalProperties, "universal_resource_access")
+		delete(additionalProperties, "universal_workflow_access")
+		delete(additionalProperties, "user_invites")
+		delete(additionalProperties, "user_list_access")
+		delete(additionalProperties, "audit_log_access")
+		delete(additionalProperties, "unpublished_release_access")
+		delete(additionalProperties, "usage_analytics_access")
+		delete(additionalProperties, "account_details_access")
+		delete(additionalProperties, "landing_page_app_id")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableGroupsGroupIdPutRequest struct {

--- a/internal/sdk/api/model__groups__group_id__put_request_members_inner.go
+++ b/internal/sdk/api/model__groups__group_id__put_request_members_inner.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type GroupsGroupIdPutRequestMembersInner struct {
 	Id string `json:"id"`
 	// Whether the user is a group admin
 	IsGroupAdmin bool `json:"is_group_admin"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GroupsGroupIdPutRequestMembersInner GroupsGroupIdPutRequestMembersInner
@@ -109,6 +109,11 @@ func (o GroupsGroupIdPutRequestMembersInner) ToMap() (map[string]interface{}, er
 	toSerialize := map[string]interface{}{}
 	toSerialize["id"] = o.Id
 	toSerialize["is_group_admin"] = o.IsGroupAdmin
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *GroupsGroupIdPutRequestMembersInner) UnmarshalJSON(data []byte) (err er
 
 	varGroupsGroupIdPutRequestMembersInner := _GroupsGroupIdPutRequestMembersInner{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGroupsGroupIdPutRequestMembersInner)
+	err = json.Unmarshal(data, &varGroupsGroupIdPutRequestMembersInner)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GroupsGroupIdPutRequestMembersInner(varGroupsGroupIdPutRequestMembersInner)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "is_group_admin")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__groups__group_id__user_invites_post_request.go
+++ b/internal/sdk/api/model__groups__group_id__user_invites_post_request.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &GroupsGroupIdUserInvitesPostRequest{}
 // GroupsGroupIdUserInvitesPostRequest User Invites to add to the group
 type GroupsGroupIdUserInvitesPostRequest struct {
 	UserInviteIds []float32 `json:"userInviteIds"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GroupsGroupIdUserInvitesPostRequest GroupsGroupIdUserInvitesPostRequest
@@ -79,6 +79,11 @@ func (o GroupsGroupIdUserInvitesPostRequest) MarshalJSON() ([]byte, error) {
 func (o GroupsGroupIdUserInvitesPostRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["userInviteIds"] = o.UserInviteIds
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *GroupsGroupIdUserInvitesPostRequest) UnmarshalJSON(data []byte) (err er
 
 	varGroupsGroupIdUserInvitesPostRequest := _GroupsGroupIdUserInvitesPostRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGroupsGroupIdUserInvitesPostRequest)
+	err = json.Unmarshal(data, &varGroupsGroupIdUserInvitesPostRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GroupsGroupIdUserInvitesPostRequest(varGroupsGroupIdUserInvitesPostRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "userInviteIds")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__groups_get_200_response.go
+++ b/internal/sdk/api/model__groups_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type GroupsGet200Response struct {
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GroupsGet200Response GroupsGet200Response
@@ -194,6 +194,11 @@ func (o GroupsGet200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *GroupsGet200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varGroupsGet200Response := _GroupsGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGroupsGet200Response)
+	err = json.Unmarshal(data, &varGroupsGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GroupsGet200Response(varGroupsGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__groups_get_200_response_data_inner.go
+++ b/internal/sdk/api/model__groups_get_200_response_data_inner.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -49,6 +48,7 @@ type GroupsGet200ResponseDataInner struct {
 	AccountDetailsAccess bool `json:"account_details_access"`
 	// The app ID of the landing page
 	LandingPageAppId NullableString `json:"landing_page_app_id"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GroupsGet200ResponseDataInner GroupsGet200ResponseDataInner
@@ -450,6 +450,11 @@ func (o GroupsGet200ResponseDataInner) ToMap() (map[string]interface{}, error) {
 	toSerialize["usage_analytics_access"] = o.UsageAnalyticsAccess
 	toSerialize["account_details_access"] = o.AccountDetailsAccess
 	toSerialize["landing_page_app_id"] = o.LandingPageAppId.Get()
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -490,15 +495,33 @@ func (o *GroupsGet200ResponseDataInner) UnmarshalJSON(data []byte) (err error) {
 
 	varGroupsGet200ResponseDataInner := _GroupsGet200ResponseDataInner{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGroupsGet200ResponseDataInner)
+	err = json.Unmarshal(data, &varGroupsGet200ResponseDataInner)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GroupsGet200ResponseDataInner(varGroupsGet200ResponseDataInner)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "members")
+		delete(additionalProperties, "universal_app_access")
+		delete(additionalProperties, "universal_resource_access")
+		delete(additionalProperties, "universal_workflow_access")
+		delete(additionalProperties, "user_invites")
+		delete(additionalProperties, "user_list_access")
+		delete(additionalProperties, "audit_log_access")
+		delete(additionalProperties, "unpublished_release_access")
+		delete(additionalProperties, "usage_analytics_access")
+		delete(additionalProperties, "account_details_access")
+		delete(additionalProperties, "landing_page_app_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__groups_post_200_response.go
+++ b/internal/sdk/api/model__groups_post_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type GroupsPost200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data GroupsPost200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GroupsPost200Response GroupsPost200Response
@@ -107,6 +107,11 @@ func (o GroupsPost200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *GroupsPost200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varGroupsPost200Response := _GroupsPost200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGroupsPost200Response)
+	err = json.Unmarshal(data, &varGroupsPost200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GroupsPost200Response(varGroupsPost200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__groups_post_200_response_data.go
+++ b/internal/sdk/api/model__groups_post_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -49,6 +48,7 @@ type GroupsPost200ResponseData struct {
 	AccountDetailsAccess bool `json:"account_details_access"`
 	// The app ID of the landing page
 	LandingPageAppId NullableString `json:"landing_page_app_id"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GroupsPost200ResponseData GroupsPost200ResponseData
@@ -450,6 +450,11 @@ func (o GroupsPost200ResponseData) ToMap() (map[string]interface{}, error) {
 	toSerialize["usage_analytics_access"] = o.UsageAnalyticsAccess
 	toSerialize["account_details_access"] = o.AccountDetailsAccess
 	toSerialize["landing_page_app_id"] = o.LandingPageAppId.Get()
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -490,15 +495,33 @@ func (o *GroupsPost200ResponseData) UnmarshalJSON(data []byte) (err error) {
 
 	varGroupsPost200ResponseData := _GroupsPost200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGroupsPost200ResponseData)
+	err = json.Unmarshal(data, &varGroupsPost200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GroupsPost200ResponseData(varGroupsPost200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "members")
+		delete(additionalProperties, "universal_app_access")
+		delete(additionalProperties, "universal_resource_access")
+		delete(additionalProperties, "universal_workflow_access")
+		delete(additionalProperties, "user_invites")
+		delete(additionalProperties, "user_list_access")
+		delete(additionalProperties, "audit_log_access")
+		delete(additionalProperties, "unpublished_release_access")
+		delete(additionalProperties, "usage_analytics_access")
+		delete(additionalProperties, "account_details_access")
+		delete(additionalProperties, "landing_page_app_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__groups_post_request.go
+++ b/internal/sdk/api/model__groups_post_request.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -44,6 +43,7 @@ type GroupsPostRequest struct {
 	AccountDetailsAccess *bool `json:"account_details_access,omitempty"`
 	// The app ID of the landing page
 	LandingPageAppId NullableString `json:"landing_page_app_id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GroupsPostRequest GroupsPostRequest
@@ -496,6 +496,11 @@ func (o GroupsPostRequest) ToMap() (map[string]interface{}, error) {
 	if o.LandingPageAppId.IsSet() {
 		toSerialize["landing_page_app_id"] = o.LandingPageAppId.Get()
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -523,15 +528,31 @@ func (o *GroupsPostRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varGroupsPostRequest := _GroupsPostRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGroupsPostRequest)
+	err = json.Unmarshal(data, &varGroupsPostRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GroupsPostRequest(varGroupsPostRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "members")
+		delete(additionalProperties, "universal_app_access")
+		delete(additionalProperties, "universal_resource_access")
+		delete(additionalProperties, "universal_workflow_access")
+		delete(additionalProperties, "user_invites")
+		delete(additionalProperties, "user_list_access")
+		delete(additionalProperties, "audit_log_access")
+		delete(additionalProperties, "unpublished_release_access")
+		delete(additionalProperties, "usage_analytics_access")
+		delete(additionalProperties, "account_details_access")
+		delete(additionalProperties, "landing_page_app_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__permissions_list_objects_post_200_response.go
+++ b/internal/sdk/api/model__permissions_list_objects_post_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type PermissionsListObjectsPost200Response struct {
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PermissionsListObjectsPost200Response PermissionsListObjectsPost200Response
@@ -194,6 +194,11 @@ func (o PermissionsListObjectsPost200Response) ToMap() (map[string]interface{}, 
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *PermissionsListObjectsPost200Response) UnmarshalJSON(data []byte) (err 
 
 	varPermissionsListObjectsPost200Response := _PermissionsListObjectsPost200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPermissionsListObjectsPost200Response)
+	err = json.Unmarshal(data, &varPermissionsListObjectsPost200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PermissionsListObjectsPost200Response(varPermissionsListObjectsPost200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__permissions_list_objects_post_200_response_data_inner_one_of.go
+++ b/internal/sdk/api/model__permissions_list_objects_post_200_response_data_inner_one_of.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type PermissionsListObjectsPost200ResponseDataInnerOneOf struct {
 	Id string `json:"id"`
 	// The access level of the folder
 	AccessLevel string `json:"access_level"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PermissionsListObjectsPost200ResponseDataInnerOneOf PermissionsListObjectsPost200ResponseDataInnerOneOf
@@ -135,6 +135,11 @@ func (o PermissionsListObjectsPost200ResponseDataInnerOneOf) ToMap() (map[string
 	toSerialize["type"] = o.Type
 	toSerialize["id"] = o.Id
 	toSerialize["access_level"] = o.AccessLevel
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -164,15 +169,22 @@ func (o *PermissionsListObjectsPost200ResponseDataInnerOneOf) UnmarshalJSON(data
 
 	varPermissionsListObjectsPost200ResponseDataInnerOneOf := _PermissionsListObjectsPost200ResponseDataInnerOneOf{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPermissionsListObjectsPost200ResponseDataInnerOneOf)
+	err = json.Unmarshal(data, &varPermissionsListObjectsPost200ResponseDataInnerOneOf)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PermissionsListObjectsPost200ResponseDataInnerOneOf(varPermissionsListObjectsPost200ResponseDataInnerOneOf)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "access_level")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__permissions_list_objects_post_200_response_data_inner_one_of_1.go
+++ b/internal/sdk/api/model__permissions_list_objects_post_200_response_data_inner_one_of_1.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type PermissionsListObjectsPost200ResponseDataInnerOneOf1 struct {
 	Id string `json:"id"`
 	// The access level of the app
 	AccessLevel string `json:"access_level"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PermissionsListObjectsPost200ResponseDataInnerOneOf1 PermissionsListObjectsPost200ResponseDataInnerOneOf1
@@ -135,6 +135,11 @@ func (o PermissionsListObjectsPost200ResponseDataInnerOneOf1) ToMap() (map[strin
 	toSerialize["type"] = o.Type
 	toSerialize["id"] = o.Id
 	toSerialize["access_level"] = o.AccessLevel
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -164,15 +169,22 @@ func (o *PermissionsListObjectsPost200ResponseDataInnerOneOf1) UnmarshalJSON(dat
 
 	varPermissionsListObjectsPost200ResponseDataInnerOneOf1 := _PermissionsListObjectsPost200ResponseDataInnerOneOf1{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPermissionsListObjectsPost200ResponseDataInnerOneOf1)
+	err = json.Unmarshal(data, &varPermissionsListObjectsPost200ResponseDataInnerOneOf1)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PermissionsListObjectsPost200ResponseDataInnerOneOf1(varPermissionsListObjectsPost200ResponseDataInnerOneOf1)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "access_level")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__permissions_list_objects_post_200_response_data_inner_one_of_2.go
+++ b/internal/sdk/api/model__permissions_list_objects_post_200_response_data_inner_one_of_2.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -25,6 +24,7 @@ type PermissionsListObjectsPost200ResponseDataInnerOneOf2 struct {
 	Id PermissionsListObjectsPost200ResponseDataInnerOneOf2Id `json:"id"`
 	// The access level of the resource
 	AccessLevel string `json:"access_level"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PermissionsListObjectsPost200ResponseDataInnerOneOf2 PermissionsListObjectsPost200ResponseDataInnerOneOf2
@@ -134,6 +134,11 @@ func (o PermissionsListObjectsPost200ResponseDataInnerOneOf2) ToMap() (map[strin
 	toSerialize["type"] = o.Type
 	toSerialize["id"] = o.Id
 	toSerialize["access_level"] = o.AccessLevel
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -163,15 +168,22 @@ func (o *PermissionsListObjectsPost200ResponseDataInnerOneOf2) UnmarshalJSON(dat
 
 	varPermissionsListObjectsPost200ResponseDataInnerOneOf2 := _PermissionsListObjectsPost200ResponseDataInnerOneOf2{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPermissionsListObjectsPost200ResponseDataInnerOneOf2)
+	err = json.Unmarshal(data, &varPermissionsListObjectsPost200ResponseDataInnerOneOf2)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PermissionsListObjectsPost200ResponseDataInnerOneOf2(varPermissionsListObjectsPost200ResponseDataInnerOneOf2)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "access_level")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__permissions_list_objects_post_200_response_data_inner_one_of_3.go
+++ b/internal/sdk/api/model__permissions_list_objects_post_200_response_data_inner_one_of_3.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type PermissionsListObjectsPost200ResponseDataInnerOneOf3 struct {
 	Id string `json:"id"`
 	// The access level of the resource configuration. Note that the access level in practice of this resource configuration could be different dependent on what the access level of the resource with the same id as the \"name\" of this resource_configuration. 
 	AccessLevel string `json:"access_level"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PermissionsListObjectsPost200ResponseDataInnerOneOf3 PermissionsListObjectsPost200ResponseDataInnerOneOf3
@@ -135,6 +135,11 @@ func (o PermissionsListObjectsPost200ResponseDataInnerOneOf3) ToMap() (map[strin
 	toSerialize["type"] = o.Type
 	toSerialize["id"] = o.Id
 	toSerialize["access_level"] = o.AccessLevel
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -164,15 +169,22 @@ func (o *PermissionsListObjectsPost200ResponseDataInnerOneOf3) UnmarshalJSON(dat
 
 	varPermissionsListObjectsPost200ResponseDataInnerOneOf3 := _PermissionsListObjectsPost200ResponseDataInnerOneOf3{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPermissionsListObjectsPost200ResponseDataInnerOneOf3)
+	err = json.Unmarshal(data, &varPermissionsListObjectsPost200ResponseDataInnerOneOf3)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PermissionsListObjectsPost200ResponseDataInnerOneOf3(varPermissionsListObjectsPost200ResponseDataInnerOneOf3)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "access_level")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__resource_configurations_get_200_response.go
+++ b/internal/sdk/api/model__resource_configurations_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type ResourceConfigurationsGet200Response struct {
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ResourceConfigurationsGet200Response ResourceConfigurationsGet200Response
@@ -194,6 +194,11 @@ func (o ResourceConfigurationsGet200Response) ToMap() (map[string]interface{}, e
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *ResourceConfigurationsGet200Response) UnmarshalJSON(data []byte) (err e
 
 	varResourceConfigurationsGet200Response := _ResourceConfigurationsGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varResourceConfigurationsGet200Response)
+	err = json.Unmarshal(data, &varResourceConfigurationsGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ResourceConfigurationsGet200Response(varResourceConfigurationsGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__resource_configurations_get_200_response_data_inner_environment.go
+++ b/internal/sdk/api/model__resource_configurations_get_200_response_data_inner_environment.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -28,6 +27,7 @@ type ResourceConfigurationsGet200ResponseDataInnerEnvironment struct {
 	Default bool `json:"default"`
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ResourceConfigurationsGet200ResponseDataInnerEnvironment ResourceConfigurationsGet200ResponseDataInnerEnvironment
@@ -243,6 +243,11 @@ func (o ResourceConfigurationsGet200ResponseDataInnerEnvironment) ToMap() (map[s
 	toSerialize["default"] = o.Default
 	toSerialize["created_at"] = o.CreatedAt
 	toSerialize["updated_at"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -276,15 +281,26 @@ func (o *ResourceConfigurationsGet200ResponseDataInnerEnvironment) UnmarshalJSON
 
 	varResourceConfigurationsGet200ResponseDataInnerEnvironment := _ResourceConfigurationsGet200ResponseDataInnerEnvironment{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varResourceConfigurationsGet200ResponseDataInnerEnvironment)
+	err = json.Unmarshal(data, &varResourceConfigurationsGet200ResponseDataInnerEnvironment)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ResourceConfigurationsGet200ResponseDataInnerEnvironment(varResourceConfigurationsGet200ResponseDataInnerEnvironment)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "color")
+		delete(additionalProperties, "default")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__resources__resource_id__get_200_response.go
+++ b/internal/sdk/api/model__resources__resource_id__get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type ResourcesResourceIdGet200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data ResourcesGet200ResponseDataInner `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ResourcesResourceIdGet200Response ResourcesResourceIdGet200Response
@@ -107,6 +107,11 @@ func (o ResourcesResourceIdGet200Response) ToMap() (map[string]interface{}, erro
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *ResourcesResourceIdGet200Response) UnmarshalJSON(data []byte) (err erro
 
 	varResourcesResourceIdGet200Response := _ResourcesResourceIdGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varResourcesResourceIdGet200Response)
+	err = json.Unmarshal(data, &varResourcesResourceIdGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ResourcesResourceIdGet200Response(varResourcesResourceIdGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__resources_get_200_response.go
+++ b/internal/sdk/api/model__resources_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type ResourcesGet200Response struct {
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ResourcesGet200Response ResourcesGet200Response
@@ -194,6 +194,11 @@ func (o ResourcesGet200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *ResourcesGet200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varResourcesGet200Response := _ResourcesGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varResourcesGet200Response)
+	err = json.Unmarshal(data, &varResourcesGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ResourcesGet200Response(varResourcesGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_config_get_200_response_data_any_of.go
+++ b/internal/sdk/api/model__source_control_config_get_200_response_data_any_of.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type SourceControlConfigGet200ResponseDataAnyOf struct {
 	DefaultBranch string `json:"default_branch"`
 	// Repositories using Toolscript are 2.0.0. Repositories using legacy YAML are 1.0.0.
 	RepoVersion *string `json:"repo_version,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlConfigGet200ResponseDataAnyOf SourceControlConfigGet200ResponseDataAnyOf
@@ -227,6 +227,11 @@ func (o SourceControlConfigGet200ResponseDataAnyOf) ToMap() (map[string]interfac
 	if !IsNil(o.RepoVersion) {
 		toSerialize["repo_version"] = o.RepoVersion
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -258,15 +263,25 @@ func (o *SourceControlConfigGet200ResponseDataAnyOf) UnmarshalJSON(data []byte) 
 
 	varSourceControlConfigGet200ResponseDataAnyOf := _SourceControlConfigGet200ResponseDataAnyOf{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlConfigGet200ResponseDataAnyOf)
+	err = json.Unmarshal(data, &varSourceControlConfigGet200ResponseDataAnyOf)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlConfigGet200ResponseDataAnyOf(varSourceControlConfigGet200ResponseDataAnyOf)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "config")
+		delete(additionalProperties, "provider")
+		delete(additionalProperties, "org")
+		delete(additionalProperties, "repo")
+		delete(additionalProperties, "default_branch")
+		delete(additionalProperties, "repo_version")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_config_get_200_response_data_any_of_1.go
+++ b/internal/sdk/api/model__source_control_config_get_200_response_data_any_of_1.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type SourceControlConfigGet200ResponseDataAnyOf1 struct {
 	DefaultBranch string `json:"default_branch"`
 	// Repositories using Toolscript are 2.0.0. Repositories using legacy YAML are 1.0.0.
 	RepoVersion *string `json:"repo_version,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlConfigGet200ResponseDataAnyOf1 SourceControlConfigGet200ResponseDataAnyOf1
@@ -227,6 +227,11 @@ func (o SourceControlConfigGet200ResponseDataAnyOf1) ToMap() (map[string]interfa
 	if !IsNil(o.RepoVersion) {
 		toSerialize["repo_version"] = o.RepoVersion
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -258,15 +263,25 @@ func (o *SourceControlConfigGet200ResponseDataAnyOf1) UnmarshalJSON(data []byte)
 
 	varSourceControlConfigGet200ResponseDataAnyOf1 := _SourceControlConfigGet200ResponseDataAnyOf1{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlConfigGet200ResponseDataAnyOf1)
+	err = json.Unmarshal(data, &varSourceControlConfigGet200ResponseDataAnyOf1)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlConfigGet200ResponseDataAnyOf1(varSourceControlConfigGet200ResponseDataAnyOf1)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "config")
+		delete(additionalProperties, "provider")
+		delete(additionalProperties, "org")
+		delete(additionalProperties, "repo")
+		delete(additionalProperties, "default_branch")
+		delete(additionalProperties, "repo_version")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_config_get_200_response_data_any_of_2.go
+++ b/internal/sdk/api/model__source_control_config_get_200_response_data_any_of_2.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type SourceControlConfigGet200ResponseDataAnyOf2 struct {
 	DefaultBranch string `json:"default_branch"`
 	// Repositories using Toolscript are 2.0.0. Repositories using legacy YAML are 1.0.0.
 	RepoVersion *string `json:"repo_version,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlConfigGet200ResponseDataAnyOf2 SourceControlConfigGet200ResponseDataAnyOf2
@@ -227,6 +227,11 @@ func (o SourceControlConfigGet200ResponseDataAnyOf2) ToMap() (map[string]interfa
 	if !IsNil(o.RepoVersion) {
 		toSerialize["repo_version"] = o.RepoVersion
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -258,15 +263,25 @@ func (o *SourceControlConfigGet200ResponseDataAnyOf2) UnmarshalJSON(data []byte)
 
 	varSourceControlConfigGet200ResponseDataAnyOf2 := _SourceControlConfigGet200ResponseDataAnyOf2{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlConfigGet200ResponseDataAnyOf2)
+	err = json.Unmarshal(data, &varSourceControlConfigGet200ResponseDataAnyOf2)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlConfigGet200ResponseDataAnyOf2(varSourceControlConfigGet200ResponseDataAnyOf2)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "config")
+		delete(additionalProperties, "provider")
+		delete(additionalProperties, "org")
+		delete(additionalProperties, "repo")
+		delete(additionalProperties, "default_branch")
+		delete(additionalProperties, "repo_version")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_config_get_200_response_data_any_of_3.go
+++ b/internal/sdk/api/model__source_control_config_get_200_response_data_any_of_3.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type SourceControlConfigGet200ResponseDataAnyOf3 struct {
 	DefaultBranch string `json:"default_branch"`
 	// Repositories using Toolscript are 2.0.0. Repositories using legacy YAML are 1.0.0.
 	RepoVersion *string `json:"repo_version,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlConfigGet200ResponseDataAnyOf3 SourceControlConfigGet200ResponseDataAnyOf3
@@ -227,6 +227,11 @@ func (o SourceControlConfigGet200ResponseDataAnyOf3) ToMap() (map[string]interfa
 	if !IsNil(o.RepoVersion) {
 		toSerialize["repo_version"] = o.RepoVersion
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -258,15 +263,25 @@ func (o *SourceControlConfigGet200ResponseDataAnyOf3) UnmarshalJSON(data []byte)
 
 	varSourceControlConfigGet200ResponseDataAnyOf3 := _SourceControlConfigGet200ResponseDataAnyOf3{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlConfigGet200ResponseDataAnyOf3)
+	err = json.Unmarshal(data, &varSourceControlConfigGet200ResponseDataAnyOf3)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlConfigGet200ResponseDataAnyOf3(varSourceControlConfigGet200ResponseDataAnyOf3)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "config")
+		delete(additionalProperties, "provider")
+		delete(additionalProperties, "org")
+		delete(additionalProperties, "repo")
+		delete(additionalProperties, "default_branch")
+		delete(additionalProperties, "repo_version")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_config_get_200_response_data_any_of_4.go
+++ b/internal/sdk/api/model__source_control_config_get_200_response_data_any_of_4.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type SourceControlConfigGet200ResponseDataAnyOf4 struct {
 	DefaultBranch string `json:"default_branch"`
 	// Repositories using Toolscript are 2.0.0. Repositories using legacy YAML are 1.0.0.
 	RepoVersion *string `json:"repo_version,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlConfigGet200ResponseDataAnyOf4 SourceControlConfigGet200ResponseDataAnyOf4
@@ -227,6 +227,11 @@ func (o SourceControlConfigGet200ResponseDataAnyOf4) ToMap() (map[string]interfa
 	if !IsNil(o.RepoVersion) {
 		toSerialize["repo_version"] = o.RepoVersion
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -258,15 +263,25 @@ func (o *SourceControlConfigGet200ResponseDataAnyOf4) UnmarshalJSON(data []byte)
 
 	varSourceControlConfigGet200ResponseDataAnyOf4 := _SourceControlConfigGet200ResponseDataAnyOf4{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlConfigGet200ResponseDataAnyOf4)
+	err = json.Unmarshal(data, &varSourceControlConfigGet200ResponseDataAnyOf4)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlConfigGet200ResponseDataAnyOf4(varSourceControlConfigGet200ResponseDataAnyOf4)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "config")
+		delete(additionalProperties, "provider")
+		delete(additionalProperties, "org")
+		delete(additionalProperties, "repo")
+		delete(additionalProperties, "default_branch")
+		delete(additionalProperties, "repo_version")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_config_post_200_response.go
+++ b/internal/sdk/api/model__source_control_config_post_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type SourceControlConfigPost200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data SourceControlConfigPost200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlConfigPost200Response SourceControlConfigPost200Response
@@ -107,6 +107,11 @@ func (o SourceControlConfigPost200Response) ToMap() (map[string]interface{}, err
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *SourceControlConfigPost200Response) UnmarshalJSON(data []byte) (err err
 
 	varSourceControlConfigPost200Response := _SourceControlConfigPost200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlConfigPost200Response)
+	err = json.Unmarshal(data, &varSourceControlConfigPost200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlConfigPost200Response(varSourceControlConfigPost200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_config_put_200_response.go
+++ b/internal/sdk/api/model__source_control_config_put_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type SourceControlConfigPut200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data SourceControlConfigPut200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlConfigPut200Response SourceControlConfigPut200Response
@@ -107,6 +107,11 @@ func (o SourceControlConfigPut200Response) ToMap() (map[string]interface{}, erro
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *SourceControlConfigPut200Response) UnmarshalJSON(data []byte) (err erro
 
 	varSourceControlConfigPut200Response := _SourceControlConfigPut200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlConfigPut200Response)
+	err = json.Unmarshal(data, &varSourceControlConfigPut200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlConfigPut200Response(varSourceControlConfigPut200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_deploy_post_200_response.go
+++ b/internal/sdk/api/model__source_control_deploy_post_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type SourceControlDeployPost200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data SourceControlDeployPost200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlDeployPost200Response SourceControlDeployPost200Response
@@ -107,6 +107,11 @@ func (o SourceControlDeployPost200Response) ToMap() (map[string]interface{}, err
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *SourceControlDeployPost200Response) UnmarshalJSON(data []byte) (err err
 
 	varSourceControlDeployPost200Response := _SourceControlDeployPost200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlDeployPost200Response)
+	err = json.Unmarshal(data, &varSourceControlDeployPost200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlDeployPost200Response(varSourceControlDeployPost200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_deploy_post_200_response_data.go
+++ b/internal/sdk/api/model__source_control_deploy_post_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type SourceControlDeployPost200ResponseData struct {
 	// The deployment ID
 	Id string `json:"id"`
 	Status string `json:"status"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlDeployPost200ResponseData SourceControlDeployPost200ResponseData
@@ -107,6 +107,11 @@ func (o SourceControlDeployPost200ResponseData) ToMap() (map[string]interface{},
 	toSerialize := map[string]interface{}{}
 	toSerialize["id"] = o.Id
 	toSerialize["status"] = o.Status
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *SourceControlDeployPost200ResponseData) UnmarshalJSON(data []byte) (err
 
 	varSourceControlDeployPost200ResponseData := _SourceControlDeployPost200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlDeployPost200ResponseData)
+	err = json.Unmarshal(data, &varSourceControlDeployPost200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlDeployPost200ResponseData(varSourceControlDeployPost200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "status")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_settings_get_200_response.go
+++ b/internal/sdk/api/model__source_control_settings_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type SourceControlSettingsGet200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data SourceControlSettingsGet200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlSettingsGet200Response SourceControlSettingsGet200Response
@@ -107,6 +107,11 @@ func (o SourceControlSettingsGet200Response) ToMap() (map[string]interface{}, er
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *SourceControlSettingsGet200Response) UnmarshalJSON(data []byte) (err er
 
 	varSourceControlSettingsGet200Response := _SourceControlSettingsGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlSettingsGet200Response)
+	err = json.Unmarshal(data, &varSourceControlSettingsGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlSettingsGet200Response(varSourceControlSettingsGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_settings_get_200_response_data.go
+++ b/internal/sdk/api/model__source_control_settings_get_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -29,6 +28,7 @@ type SourceControlSettingsGet200ResponseData struct {
 	CustomPullRequestTemplate string `json:"custom_pull_request_template"`
 	// When set to true, creates a read-only instance of Retool, where app editing is disabled. Defaults to false.
 	VersionControlLocked bool `json:"version_control_locked"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlSettingsGet200ResponseData SourceControlSettingsGet200ResponseData
@@ -164,6 +164,11 @@ func (o SourceControlSettingsGet200ResponseData) ToMap() (map[string]interface{}
 	toSerialize["custom_pull_request_template_enabled"] = o.CustomPullRequestTemplateEnabled
 	toSerialize["custom_pull_request_template"] = o.CustomPullRequestTemplate
 	toSerialize["version_control_locked"] = o.VersionControlLocked
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -194,15 +199,23 @@ func (o *SourceControlSettingsGet200ResponseData) UnmarshalJSON(data []byte) (er
 
 	varSourceControlSettingsGet200ResponseData := _SourceControlSettingsGet200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlSettingsGet200ResponseData)
+	err = json.Unmarshal(data, &varSourceControlSettingsGet200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlSettingsGet200ResponseData(varSourceControlSettingsGet200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "auto_branch_naming_enabled")
+		delete(additionalProperties, "custom_pull_request_template_enabled")
+		delete(additionalProperties, "custom_pull_request_template")
+		delete(additionalProperties, "version_control_locked")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_settings_put_200_response.go
+++ b/internal/sdk/api/model__source_control_settings_put_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type SourceControlSettingsPut200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data SourceControlSettingsPut200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlSettingsPut200Response SourceControlSettingsPut200Response
@@ -107,6 +107,11 @@ func (o SourceControlSettingsPut200Response) ToMap() (map[string]interface{}, er
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *SourceControlSettingsPut200Response) UnmarshalJSON(data []byte) (err er
 
 	varSourceControlSettingsPut200Response := _SourceControlSettingsPut200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlSettingsPut200Response)
+	err = json.Unmarshal(data, &varSourceControlSettingsPut200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlSettingsPut200Response(varSourceControlSettingsPut200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_settings_put_200_response_data.go
+++ b/internal/sdk/api/model__source_control_settings_put_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -29,6 +28,7 @@ type SourceControlSettingsPut200ResponseData struct {
 	CustomPullRequestTemplate string `json:"custom_pull_request_template"`
 	// When set to true, creates a read-only instance of Retool, where app editing is disabled. Defaults to false.
 	VersionControlLocked bool `json:"version_control_locked"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlSettingsPut200ResponseData SourceControlSettingsPut200ResponseData
@@ -164,6 +164,11 @@ func (o SourceControlSettingsPut200ResponseData) ToMap() (map[string]interface{}
 	toSerialize["custom_pull_request_template_enabled"] = o.CustomPullRequestTemplateEnabled
 	toSerialize["custom_pull_request_template"] = o.CustomPullRequestTemplate
 	toSerialize["version_control_locked"] = o.VersionControlLocked
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -194,15 +199,23 @@ func (o *SourceControlSettingsPut200ResponseData) UnmarshalJSON(data []byte) (er
 
 	varSourceControlSettingsPut200ResponseData := _SourceControlSettingsPut200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlSettingsPut200ResponseData)
+	err = json.Unmarshal(data, &varSourceControlSettingsPut200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlSettingsPut200ResponseData(varSourceControlSettingsPut200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "auto_branch_naming_enabled")
+		delete(additionalProperties, "custom_pull_request_template_enabled")
+		delete(additionalProperties, "custom_pull_request_template")
+		delete(additionalProperties, "version_control_locked")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_test_connection_get_200_response.go
+++ b/internal/sdk/api/model__source_control_test_connection_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type SourceControlTestConnectionGet200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data SourceControlTestConnectionGet200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlTestConnectionGet200Response SourceControlTestConnectionGet200Response
@@ -107,6 +107,11 @@ func (o SourceControlTestConnectionGet200Response) ToMap() (map[string]interface
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *SourceControlTestConnectionGet200Response) UnmarshalJSON(data []byte) (
 
 	varSourceControlTestConnectionGet200Response := _SourceControlTestConnectionGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlTestConnectionGet200Response)
+	err = json.Unmarshal(data, &varSourceControlTestConnectionGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlTestConnectionGet200Response(varSourceControlTestConnectionGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_test_connection_get_200_response_data_any_of.go
+++ b/internal/sdk/api/model__source_control_test_connection_get_200_response_data_any_of.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -25,6 +24,7 @@ type SourceControlTestConnectionGet200ResponseDataAnyOf struct {
 	Success bool `json:"success"`
 	// Error message
 	Message string `json:"message"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlTestConnectionGet200ResponseDataAnyOf SourceControlTestConnectionGet200ResponseDataAnyOf
@@ -108,6 +108,11 @@ func (o SourceControlTestConnectionGet200ResponseDataAnyOf) ToMap() (map[string]
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["message"] = o.Message
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -136,15 +141,21 @@ func (o *SourceControlTestConnectionGet200ResponseDataAnyOf) UnmarshalJSON(data 
 
 	varSourceControlTestConnectionGet200ResponseDataAnyOf := _SourceControlTestConnectionGet200ResponseDataAnyOf{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlTestConnectionGet200ResponseDataAnyOf)
+	err = json.Unmarshal(data, &varSourceControlTestConnectionGet200ResponseDataAnyOf)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlTestConnectionGet200ResponseDataAnyOf(varSourceControlTestConnectionGet200ResponseDataAnyOf)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "message")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_test_connection_get_200_response_data_any_of_1.go
+++ b/internal/sdk/api/model__source_control_test_connection_get_200_response_data_any_of_1.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &SourceControlTestConnectionGet200ResponseDataAnyOf1{}
 type SourceControlTestConnectionGet200ResponseDataAnyOf1 struct {
 	// Test connection succeeded
 	Success bool `json:"success"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlTestConnectionGet200ResponseDataAnyOf1 SourceControlTestConnectionGet200ResponseDataAnyOf1
@@ -80,6 +80,11 @@ func (o SourceControlTestConnectionGet200ResponseDataAnyOf1) MarshalJSON() ([]by
 func (o SourceControlTestConnectionGet200ResponseDataAnyOf1) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -107,15 +112,20 @@ func (o *SourceControlTestConnectionGet200ResponseDataAnyOf1) UnmarshalJSON(data
 
 	varSourceControlTestConnectionGet200ResponseDataAnyOf1 := _SourceControlTestConnectionGet200ResponseDataAnyOf1{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlTestConnectionGet200ResponseDataAnyOf1)
+	err = json.Unmarshal(data, &varSourceControlTestConnectionGet200ResponseDataAnyOf1)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlTestConnectionGet200ResponseDataAnyOf1(varSourceControlTestConnectionGet200ResponseDataAnyOf1)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_test_deploy_post_200_response.go
+++ b/internal/sdk/api/model__source_control_test_deploy_post_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type SourceControlTestDeployPost200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data SourceControlTestDeployPost200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlTestDeployPost200Response SourceControlTestDeployPost200Response
@@ -107,6 +107,11 @@ func (o SourceControlTestDeployPost200Response) ToMap() (map[string]interface{},
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *SourceControlTestDeployPost200Response) UnmarshalJSON(data []byte) (err
 
 	varSourceControlTestDeployPost200Response := _SourceControlTestDeployPost200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlTestDeployPost200Response)
+	err = json.Unmarshal(data, &varSourceControlTestDeployPost200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlTestDeployPost200Response(varSourceControlTestDeployPost200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_test_deploy_post_200_response_data_any_of.go
+++ b/internal/sdk/api/model__source_control_test_deploy_post_200_response_data_any_of.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -25,6 +24,7 @@ type SourceControlTestDeployPost200ResponseDataAnyOf struct {
 	Success bool `json:"success"`
 	// Error message
 	Message string `json:"message"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlTestDeployPost200ResponseDataAnyOf SourceControlTestDeployPost200ResponseDataAnyOf
@@ -108,6 +108,11 @@ func (o SourceControlTestDeployPost200ResponseDataAnyOf) ToMap() (map[string]int
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["message"] = o.Message
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -136,15 +141,21 @@ func (o *SourceControlTestDeployPost200ResponseDataAnyOf) UnmarshalJSON(data []b
 
 	varSourceControlTestDeployPost200ResponseDataAnyOf := _SourceControlTestDeployPost200ResponseDataAnyOf{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlTestDeployPost200ResponseDataAnyOf)
+	err = json.Unmarshal(data, &varSourceControlTestDeployPost200ResponseDataAnyOf)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlTestDeployPost200ResponseDataAnyOf(varSourceControlTestDeployPost200ResponseDataAnyOf)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "message")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_test_deploy_post_200_response_data_any_of_1.go
+++ b/internal/sdk/api/model__source_control_test_deploy_post_200_response_data_any_of_1.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &SourceControlTestDeployPost200ResponseDataAnyOf1{}
 type SourceControlTestDeployPost200ResponseDataAnyOf1 struct {
 	// Deployment succeeded
 	Success bool `json:"success"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlTestDeployPost200ResponseDataAnyOf1 SourceControlTestDeployPost200ResponseDataAnyOf1
@@ -80,6 +80,11 @@ func (o SourceControlTestDeployPost200ResponseDataAnyOf1) MarshalJSON() ([]byte,
 func (o SourceControlTestDeployPost200ResponseDataAnyOf1) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -107,15 +112,20 @@ func (o *SourceControlTestDeployPost200ResponseDataAnyOf1) UnmarshalJSON(data []
 
 	varSourceControlTestDeployPost200ResponseDataAnyOf1 := _SourceControlTestDeployPost200ResponseDataAnyOf1{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlTestDeployPost200ResponseDataAnyOf1)
+	err = json.Unmarshal(data, &varSourceControlTestDeployPost200ResponseDataAnyOf1)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlTestDeployPost200ResponseDataAnyOf1(varSourceControlTestDeployPost200ResponseDataAnyOf1)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__source_control_test_deploy_post_request_deploy_params.go
+++ b/internal/sdk/api/model__source_control_test_deploy_post_request_deploy_params.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type SourceControlTestDeployPostRequestDeployParams struct {
 	// The commit SHA to dry deploy
 	CommitSha string `json:"commit_sha"`
 	IsFullSync *bool `json:"is_full_sync,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlTestDeployPostRequestDeployParams SourceControlTestDeployPostRequestDeployParams
@@ -116,6 +116,11 @@ func (o SourceControlTestDeployPostRequestDeployParams) ToMap() (map[string]inte
 	if !IsNil(o.IsFullSync) {
 		toSerialize["is_full_sync"] = o.IsFullSync
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -143,15 +148,21 @@ func (o *SourceControlTestDeployPostRequestDeployParams) UnmarshalJSON(data []by
 
 	varSourceControlTestDeployPostRequestDeployParams := _SourceControlTestDeployPostRequestDeployParams{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlTestDeployPostRequestDeployParams)
+	err = json.Unmarshal(data, &varSourceControlTestDeployPostRequestDeployParams)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlTestDeployPostRequestDeployParams(varSourceControlTestDeployPostRequestDeployParams)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "commit_sha")
+		delete(additionalProperties, "is_full_sync")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__spaces_copy_elements_post_201_response.go
+++ b/internal/sdk/api/model__spaces_copy_elements_post_201_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type SpacesCopyElementsPost201Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data SpacesCopyElementsPost201ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SpacesCopyElementsPost201Response SpacesCopyElementsPost201Response
@@ -107,6 +107,11 @@ func (o SpacesCopyElementsPost201Response) ToMap() (map[string]interface{}, erro
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *SpacesCopyElementsPost201Response) UnmarshalJSON(data []byte) (err erro
 
 	varSpacesCopyElementsPost201Response := _SpacesCopyElementsPost201Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSpacesCopyElementsPost201Response)
+	err = json.Unmarshal(data, &varSpacesCopyElementsPost201Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SpacesCopyElementsPost201Response(varSpacesCopyElementsPost201Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__spaces_copy_elements_post_201_response_data.go
+++ b/internal/sdk/api/model__spaces_copy_elements_post_201_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -29,6 +28,7 @@ type SpacesCopyElementsPost201ResponseData struct {
 	AppIds []string `json:"app_ids"`
 	// The uuids of the copied workflows.
 	WorkflowIds []string `json:"workflow_ids"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SpacesCopyElementsPost201ResponseData SpacesCopyElementsPost201ResponseData
@@ -164,6 +164,11 @@ func (o SpacesCopyElementsPost201ResponseData) ToMap() (map[string]interface{}, 
 	toSerialize["query_library_query_ids"] = o.QueryLibraryQueryIds
 	toSerialize["app_ids"] = o.AppIds
 	toSerialize["workflow_ids"] = o.WorkflowIds
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -194,15 +199,23 @@ func (o *SpacesCopyElementsPost201ResponseData) UnmarshalJSON(data []byte) (err 
 
 	varSpacesCopyElementsPost201ResponseData := _SpacesCopyElementsPost201ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSpacesCopyElementsPost201ResponseData)
+	err = json.Unmarshal(data, &varSpacesCopyElementsPost201ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SpacesCopyElementsPost201ResponseData(varSpacesCopyElementsPost201ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "resource_ids")
+		delete(additionalProperties, "query_library_query_ids")
+		delete(additionalProperties, "app_ids")
+		delete(additionalProperties, "workflow_ids")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__spaces_get_200_response.go
+++ b/internal/sdk/api/model__spaces_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type SpacesGet200Response struct {
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SpacesGet200Response SpacesGet200Response
@@ -194,6 +194,11 @@ func (o SpacesGet200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *SpacesGet200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varSpacesGet200Response := _SpacesGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSpacesGet200Response)
+	err = json.Unmarshal(data, &varSpacesGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SpacesGet200Response(varSpacesGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__spaces_post_200_response.go
+++ b/internal/sdk/api/model__spaces_post_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type SpacesPost200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data SpacesPost200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SpacesPost200Response SpacesPost200Response
@@ -107,6 +107,11 @@ func (o SpacesPost200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *SpacesPost200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varSpacesPost200Response := _SpacesPost200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSpacesPost200Response)
+	err = json.Unmarshal(data, &varSpacesPost200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SpacesPost200Response(varSpacesPost200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__spaces_post_request_options.go
+++ b/internal/sdk/api/model__spaces_post_request_options.go
@@ -27,7 +27,10 @@ type SpacesPostRequestOptions struct {
 	UsersToCopyAsAdmins []string `json:"users_to_copy_as_admins,omitempty"`
 	// Create an admin user in the new space for the creator instead of just sending out an invite.
 	CreateAdminUser *bool `json:"create_admin_user,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpacesPostRequestOptions SpacesPostRequestOptions
 
 // NewSpacesPostRequestOptions instantiates a new SpacesPostRequestOptions object
 // This constructor will assign default values to properties that have it defined,
@@ -196,7 +199,36 @@ func (o SpacesPostRequestOptions) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.CreateAdminUser) {
 		toSerialize["create_admin_user"] = o.CreateAdminUser
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SpacesPostRequestOptions) UnmarshalJSON(data []byte) (err error) {
+	varSpacesPostRequestOptions := _SpacesPostRequestOptions{}
+
+	err = json.Unmarshal(data, &varSpacesPostRequestOptions)
+
+	if err != nil {
+		return err
+	}
+
+	*o = SpacesPostRequestOptions(varSpacesPostRequestOptions)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "copy_sso_settings")
+		delete(additionalProperties, "copy_branding_and_themes_settings")
+		delete(additionalProperties, "users_to_copy_as_admins")
+		delete(additionalProperties, "create_admin_user")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpacesPostRequestOptions struct {

--- a/internal/sdk/api/model__sso_config_post_200_response.go
+++ b/internal/sdk/api/model__sso_config_post_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type SsoConfigPost200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data SsoConfigPost200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SsoConfigPost200Response SsoConfigPost200Response
@@ -107,6 +107,11 @@ func (o SsoConfigPost200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *SsoConfigPost200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varSsoConfigPost200Response := _SsoConfigPost200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSsoConfigPost200Response)
+	err = json.Unmarshal(data, &varSsoConfigPost200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SsoConfigPost200Response(varSsoConfigPost200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__user_attributes_get_200_response.go
+++ b/internal/sdk/api/model__user_attributes_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type UserAttributesGet200Response struct {
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UserAttributesGet200Response UserAttributesGet200Response
@@ -194,6 +194,11 @@ func (o UserAttributesGet200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *UserAttributesGet200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varUserAttributesGet200Response := _UserAttributesGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUserAttributesGet200Response)
+	err = json.Unmarshal(data, &varUserAttributesGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UserAttributesGet200Response(varUserAttributesGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__user_attributes_get_200_response_data_inner.go
+++ b/internal/sdk/api/model__user_attributes_get_200_response_data_inner.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -33,6 +32,7 @@ type UserAttributesGet200ResponseDataInner struct {
 	DefaultValue NullableString `json:"default_value"`
 	// The name of the Intercom user attribute that this attribute should be mapped to
 	IntercomAttributeName NullableString `json:"intercom_attribute_name"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UserAttributesGet200ResponseDataInner UserAttributesGet200ResponseDataInner
@@ -224,6 +224,11 @@ func (o UserAttributesGet200ResponseDataInner) ToMap() (map[string]interface{}, 
 	toSerialize["data_type"] = o.DataType
 	toSerialize["default_value"] = o.DefaultValue.Get()
 	toSerialize["intercom_attribute_name"] = o.IntercomAttributeName.Get()
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -256,15 +261,25 @@ func (o *UserAttributesGet200ResponseDataInner) UnmarshalJSON(data []byte) (err 
 
 	varUserAttributesGet200ResponseDataInner := _UserAttributesGet200ResponseDataInner{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUserAttributesGet200ResponseDataInner)
+	err = json.Unmarshal(data, &varUserAttributesGet200ResponseDataInner)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UserAttributesGet200ResponseDataInner(varUserAttributesGet200ResponseDataInner)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "label")
+		delete(additionalProperties, "data_type")
+		delete(additionalProperties, "default_value")
+		delete(additionalProperties, "intercom_attribute_name")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__user_invites__user_invite_id__get_200_response.go
+++ b/internal/sdk/api/model__user_invites__user_invite_id__get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type UserInvitesUserInviteIdGet200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data GroupsGroupIdGet200ResponseDataUserInvitesInner `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UserInvitesUserInviteIdGet200Response UserInvitesUserInviteIdGet200Response
@@ -107,6 +107,11 @@ func (o UserInvitesUserInviteIdGet200Response) ToMap() (map[string]interface{}, 
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *UserInvitesUserInviteIdGet200Response) UnmarshalJSON(data []byte) (err 
 
 	varUserInvitesUserInviteIdGet200Response := _UserInvitesUserInviteIdGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUserInvitesUserInviteIdGet200Response)
+	err = json.Unmarshal(data, &varUserInvitesUserInviteIdGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UserInvitesUserInviteIdGet200Response(varUserInvitesUserInviteIdGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__user_invites__user_invite_id__user_attributes__attribute_name__delete_200_response.go
+++ b/internal/sdk/api/model__user_invites__user_invite_id__user_attributes__attribute_name__delete_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type UserInvitesUserInviteIdUserAttributesAttributeNameDelete200Response struct 
 	// API request succeeded
 	Success bool `json:"success"`
 	Data UserInvitesUserInviteIdUserAttributesAttributeNameDelete200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UserInvitesUserInviteIdUserAttributesAttributeNameDelete200Response UserInvitesUserInviteIdUserAttributesAttributeNameDelete200Response
@@ -107,6 +107,11 @@ func (o UserInvitesUserInviteIdUserAttributesAttributeNameDelete200Response) ToM
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *UserInvitesUserInviteIdUserAttributesAttributeNameDelete200Response) Un
 
 	varUserInvitesUserInviteIdUserAttributesAttributeNameDelete200Response := _UserInvitesUserInviteIdUserAttributesAttributeNameDelete200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUserInvitesUserInviteIdUserAttributesAttributeNameDelete200Response)
+	err = json.Unmarshal(data, &varUserInvitesUserInviteIdUserAttributesAttributeNameDelete200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UserInvitesUserInviteIdUserAttributesAttributeNameDelete200Response(varUserInvitesUserInviteIdUserAttributesAttributeNameDelete200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__user_invites__user_invite_id__user_attributes__attribute_name__delete_200_response_data.go
+++ b/internal/sdk/api/model__user_invites__user_invite_id__user_attributes__attribute_name__delete_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &UserInvitesUserInviteIdUserAttributesAttributeNameDelete
 type UserInvitesUserInviteIdUserAttributesAttributeNameDelete200ResponseData struct {
 	// The updated user metadata
 	Metadata map[string]interface{} `json:"metadata"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UserInvitesUserInviteIdUserAttributesAttributeNameDelete200ResponseData UserInvitesUserInviteIdUserAttributesAttributeNameDelete200ResponseData
@@ -80,6 +80,11 @@ func (o UserInvitesUserInviteIdUserAttributesAttributeNameDelete200ResponseData)
 func (o UserInvitesUserInviteIdUserAttributesAttributeNameDelete200ResponseData) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["metadata"] = o.Metadata
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -107,15 +112,20 @@ func (o *UserInvitesUserInviteIdUserAttributesAttributeNameDelete200ResponseData
 
 	varUserInvitesUserInviteIdUserAttributesAttributeNameDelete200ResponseData := _UserInvitesUserInviteIdUserAttributesAttributeNameDelete200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUserInvitesUserInviteIdUserAttributesAttributeNameDelete200ResponseData)
+	err = json.Unmarshal(data, &varUserInvitesUserInviteIdUserAttributesAttributeNameDelete200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UserInvitesUserInviteIdUserAttributesAttributeNameDelete200ResponseData(varUserInvitesUserInviteIdUserAttributesAttributeNameDelete200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "metadata")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__user_invites__user_invite_id__user_attributes_post_200_response.go
+++ b/internal/sdk/api/model__user_invites__user_invite_id__user_attributes_post_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type UserInvitesUserInviteIdUserAttributesPost200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data UserInvitesUserInviteIdUserAttributesPost200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UserInvitesUserInviteIdUserAttributesPost200Response UserInvitesUserInviteIdUserAttributesPost200Response
@@ -107,6 +107,11 @@ func (o UserInvitesUserInviteIdUserAttributesPost200Response) ToMap() (map[strin
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *UserInvitesUserInviteIdUserAttributesPost200Response) UnmarshalJSON(dat
 
 	varUserInvitesUserInviteIdUserAttributesPost200Response := _UserInvitesUserInviteIdUserAttributesPost200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUserInvitesUserInviteIdUserAttributesPost200Response)
+	err = json.Unmarshal(data, &varUserInvitesUserInviteIdUserAttributesPost200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UserInvitesUserInviteIdUserAttributesPost200Response(varUserInvitesUserInviteIdUserAttributesPost200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__user_invites__user_invite_id__user_attributes_post_200_response_data.go
+++ b/internal/sdk/api/model__user_invites__user_invite_id__user_attributes_post_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &UserInvitesUserInviteIdUserAttributesPost200ResponseData
 type UserInvitesUserInviteIdUserAttributesPost200ResponseData struct {
 	// The updated user invite metadata, containing the new attribute value
 	Metadata map[string]interface{} `json:"metadata"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UserInvitesUserInviteIdUserAttributesPost200ResponseData UserInvitesUserInviteIdUserAttributesPost200ResponseData
@@ -80,6 +80,11 @@ func (o UserInvitesUserInviteIdUserAttributesPost200ResponseData) MarshalJSON() 
 func (o UserInvitesUserInviteIdUserAttributesPost200ResponseData) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["metadata"] = o.Metadata
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -107,15 +112,20 @@ func (o *UserInvitesUserInviteIdUserAttributesPost200ResponseData) UnmarshalJSON
 
 	varUserInvitesUserInviteIdUserAttributesPost200ResponseData := _UserInvitesUserInviteIdUserAttributesPost200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUserInvitesUserInviteIdUserAttributesPost200ResponseData)
+	err = json.Unmarshal(data, &varUserInvitesUserInviteIdUserAttributesPost200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UserInvitesUserInviteIdUserAttributesPost200ResponseData(varUserInvitesUserInviteIdUserAttributesPost200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "metadata")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__user_invites__user_invite_id__user_attributes_post_request.go
+++ b/internal/sdk/api/model__user_invites__user_invite_id__user_attributes_post_request.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -25,6 +24,7 @@ type UserInvitesUserInviteIdUserAttributesPostRequest struct {
 	Name string `json:"name"`
 	// The value of the user attribute
 	Value NullableString `json:"value"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UserInvitesUserInviteIdUserAttributesPostRequest UserInvitesUserInviteIdUserAttributesPostRequest
@@ -110,6 +110,11 @@ func (o UserInvitesUserInviteIdUserAttributesPostRequest) ToMap() (map[string]in
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
 	toSerialize["value"] = o.Value.Get()
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -138,15 +143,21 @@ func (o *UserInvitesUserInviteIdUserAttributesPostRequest) UnmarshalJSON(data []
 
 	varUserInvitesUserInviteIdUserAttributesPostRequest := _UserInvitesUserInviteIdUserAttributesPostRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUserInvitesUserInviteIdUserAttributesPostRequest)
+	err = json.Unmarshal(data, &varUserInvitesUserInviteIdUserAttributesPostRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UserInvitesUserInviteIdUserAttributesPostRequest(varUserInvitesUserInviteIdUserAttributesPostRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "value")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__user_invites_get_200_response.go
+++ b/internal/sdk/api/model__user_invites_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type UserInvitesGet200Response struct {
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UserInvitesGet200Response UserInvitesGet200Response
@@ -194,6 +194,11 @@ func (o UserInvitesGet200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *UserInvitesGet200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varUserInvitesGet200Response := _UserInvitesGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUserInvitesGet200Response)
+	err = json.Unmarshal(data, &varUserInvitesGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UserInvitesGet200Response(varUserInvitesGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__user_invites_post_200_response.go
+++ b/internal/sdk/api/model__user_invites_post_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type UserInvitesPost200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data UserInvitesPost200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UserInvitesPost200Response UserInvitesPost200Response
@@ -107,6 +107,11 @@ func (o UserInvitesPost200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *UserInvitesPost200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varUserInvitesPost200Response := _UserInvitesPost200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUserInvitesPost200Response)
+	err = json.Unmarshal(data, &varUserInvitesPost200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UserInvitesPost200Response(varUserInvitesPost200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__user_invites_post_200_response_data.go
+++ b/internal/sdk/api/model__user_invites_post_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -32,6 +31,7 @@ type UserInvitesPost200ResponseData struct {
 	Metadata map[string]interface{} `json:"metadata"`
 	CreatedAt string `json:"created_at"`
 	InviteLink *string `json:"invite_link,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UserInvitesPost200ResponseData UserInvitesPost200ResponseData
@@ -368,6 +368,11 @@ func (o UserInvitesPost200ResponseData) ToMap() (map[string]interface{}, error) 
 	if !IsNil(o.InviteLink) {
 		toSerialize["invite_link"] = o.InviteLink
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -404,15 +409,30 @@ func (o *UserInvitesPost200ResponseData) UnmarshalJSON(data []byte) (err error) 
 
 	varUserInvitesPost200ResponseData := _UserInvitesPost200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUserInvitesPost200ResponseData)
+	err = json.Unmarshal(data, &varUserInvitesPost200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UserInvitesPost200ResponseData(varUserInvitesPost200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "invited_by")
+		delete(additionalProperties, "invited_email")
+		delete(additionalProperties, "expires_at")
+		delete(additionalProperties, "claimed_by")
+		delete(additionalProperties, "claimed_at")
+		delete(additionalProperties, "user_type")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "invite_link")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__users__user_id__get_200_response.go
+++ b/internal/sdk/api/model__users__user_id__get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type UsersUserIdGet200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data UsersUserIdGet200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UsersUserIdGet200Response UsersUserIdGet200Response
@@ -107,6 +107,11 @@ func (o UsersUserIdGet200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *UsersUserIdGet200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varUsersUserIdGet200Response := _UsersUserIdGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUsersUserIdGet200Response)
+	err = json.Unmarshal(data, &varUsersUserIdGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UsersUserIdGet200Response(varUsersUserIdGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__users__user_id__patch_request_operations_inner_any_of.go
+++ b/internal/sdk/api/model__users__user_id__patch_request_operations_inner_any_of.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -25,6 +24,7 @@ type UsersUserIdPatchRequestOperationsInnerAnyOf struct {
 	Path string `json:"path"`
 	// A JSON value
 	Value interface{} `json:"value,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UsersUserIdPatchRequestOperationsInnerAnyOf UsersUserIdPatchRequestOperationsInnerAnyOf
@@ -144,6 +144,11 @@ func (o UsersUserIdPatchRequestOperationsInnerAnyOf) ToMap() (map[string]interfa
 	if o.Value != nil {
 		toSerialize["value"] = o.Value
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -172,15 +177,22 @@ func (o *UsersUserIdPatchRequestOperationsInnerAnyOf) UnmarshalJSON(data []byte)
 
 	varUsersUserIdPatchRequestOperationsInnerAnyOf := _UsersUserIdPatchRequestOperationsInnerAnyOf{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUsersUserIdPatchRequestOperationsInnerAnyOf)
+	err = json.Unmarshal(data, &varUsersUserIdPatchRequestOperationsInnerAnyOf)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UsersUserIdPatchRequestOperationsInnerAnyOf(varUsersUserIdPatchRequestOperationsInnerAnyOf)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "op")
+		delete(additionalProperties, "path")
+		delete(additionalProperties, "value")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__users__user_id__patch_request_operations_inner_any_of_1.go
+++ b/internal/sdk/api/model__users__user_id__patch_request_operations_inner_any_of_1.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &UsersUserIdPatchRequestOperationsInnerAnyOf1{}
 type UsersUserIdPatchRequestOperationsInnerAnyOf1 struct {
 	Op string `json:"op"`
 	Path string `json:"path"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UsersUserIdPatchRequestOperationsInnerAnyOf1 UsersUserIdPatchRequestOperationsInnerAnyOf1
@@ -106,6 +106,11 @@ func (o UsersUserIdPatchRequestOperationsInnerAnyOf1) ToMap() (map[string]interf
 	toSerialize := map[string]interface{}{}
 	toSerialize["op"] = o.Op
 	toSerialize["path"] = o.Path
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -134,15 +139,21 @@ func (o *UsersUserIdPatchRequestOperationsInnerAnyOf1) UnmarshalJSON(data []byte
 
 	varUsersUserIdPatchRequestOperationsInnerAnyOf1 := _UsersUserIdPatchRequestOperationsInnerAnyOf1{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUsersUserIdPatchRequestOperationsInnerAnyOf1)
+	err = json.Unmarshal(data, &varUsersUserIdPatchRequestOperationsInnerAnyOf1)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UsersUserIdPatchRequestOperationsInnerAnyOf1(varUsersUserIdPatchRequestOperationsInnerAnyOf1)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "op")
+		delete(additionalProperties, "path")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__users__user_id__patch_request_operations_inner_any_of_2.go
+++ b/internal/sdk/api/model__users__user_id__patch_request_operations_inner_any_of_2.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -25,6 +24,7 @@ type UsersUserIdPatchRequestOperationsInnerAnyOf2 struct {
 	Path string `json:"path"`
 	// A JSON value
 	Value interface{} `json:"value,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UsersUserIdPatchRequestOperationsInnerAnyOf2 UsersUserIdPatchRequestOperationsInnerAnyOf2
@@ -144,6 +144,11 @@ func (o UsersUserIdPatchRequestOperationsInnerAnyOf2) ToMap() (map[string]interf
 	if o.Value != nil {
 		toSerialize["value"] = o.Value
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -172,15 +177,22 @@ func (o *UsersUserIdPatchRequestOperationsInnerAnyOf2) UnmarshalJSON(data []byte
 
 	varUsersUserIdPatchRequestOperationsInnerAnyOf2 := _UsersUserIdPatchRequestOperationsInnerAnyOf2{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUsersUserIdPatchRequestOperationsInnerAnyOf2)
+	err = json.Unmarshal(data, &varUsersUserIdPatchRequestOperationsInnerAnyOf2)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UsersUserIdPatchRequestOperationsInnerAnyOf2(varUsersUserIdPatchRequestOperationsInnerAnyOf2)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "op")
+		delete(additionalProperties, "path")
+		delete(additionalProperties, "value")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__users__user_id__user_attributes__attribute_name__delete_200_response.go
+++ b/internal/sdk/api/model__users__user_id__user_attributes__attribute_name__delete_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type UsersUserIdUserAttributesAttributeNameDelete200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data UsersUserIdUserAttributesAttributeNameDelete200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UsersUserIdUserAttributesAttributeNameDelete200Response UsersUserIdUserAttributesAttributeNameDelete200Response
@@ -107,6 +107,11 @@ func (o UsersUserIdUserAttributesAttributeNameDelete200Response) ToMap() (map[st
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *UsersUserIdUserAttributesAttributeNameDelete200Response) UnmarshalJSON(
 
 	varUsersUserIdUserAttributesAttributeNameDelete200Response := _UsersUserIdUserAttributesAttributeNameDelete200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUsersUserIdUserAttributesAttributeNameDelete200Response)
+	err = json.Unmarshal(data, &varUsersUserIdUserAttributesAttributeNameDelete200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UsersUserIdUserAttributesAttributeNameDelete200Response(varUsersUserIdUserAttributesAttributeNameDelete200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__users__user_id__user_attributes__attribute_name__delete_200_response_data.go
+++ b/internal/sdk/api/model__users__user_id__user_attributes__attribute_name__delete_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &UsersUserIdUserAttributesAttributeNameDelete200ResponseD
 type UsersUserIdUserAttributesAttributeNameDelete200ResponseData struct {
 	// The updated user metadata, without the deleted attribute
 	Metadata map[string]interface{} `json:"metadata"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UsersUserIdUserAttributesAttributeNameDelete200ResponseData UsersUserIdUserAttributesAttributeNameDelete200ResponseData
@@ -80,6 +80,11 @@ func (o UsersUserIdUserAttributesAttributeNameDelete200ResponseData) MarshalJSON
 func (o UsersUserIdUserAttributesAttributeNameDelete200ResponseData) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["metadata"] = o.Metadata
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -107,15 +112,20 @@ func (o *UsersUserIdUserAttributesAttributeNameDelete200ResponseData) UnmarshalJ
 
 	varUsersUserIdUserAttributesAttributeNameDelete200ResponseData := _UsersUserIdUserAttributesAttributeNameDelete200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUsersUserIdUserAttributesAttributeNameDelete200ResponseData)
+	err = json.Unmarshal(data, &varUsersUserIdUserAttributesAttributeNameDelete200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UsersUserIdUserAttributesAttributeNameDelete200ResponseData(varUsersUserIdUserAttributesAttributeNameDelete200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "metadata")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__users__user_id__user_attributes_post_200_response.go
+++ b/internal/sdk/api/model__users__user_id__user_attributes_post_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type UsersUserIdUserAttributesPost200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data UsersUserIdUserAttributesPost200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UsersUserIdUserAttributesPost200Response UsersUserIdUserAttributesPost200Response
@@ -107,6 +107,11 @@ func (o UsersUserIdUserAttributesPost200Response) ToMap() (map[string]interface{
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *UsersUserIdUserAttributesPost200Response) UnmarshalJSON(data []byte) (e
 
 	varUsersUserIdUserAttributesPost200Response := _UsersUserIdUserAttributesPost200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUsersUserIdUserAttributesPost200Response)
+	err = json.Unmarshal(data, &varUsersUserIdUserAttributesPost200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UsersUserIdUserAttributesPost200Response(varUsersUserIdUserAttributesPost200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__users__user_id__user_attributes_post_200_response_data.go
+++ b/internal/sdk/api/model__users__user_id__user_attributes_post_200_response_data.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &UsersUserIdUserAttributesPost200ResponseData{}
 type UsersUserIdUserAttributesPost200ResponseData struct {
 	// The updated user metadata, containing the new attribute value
 	Metadata map[string]interface{} `json:"metadata"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UsersUserIdUserAttributesPost200ResponseData UsersUserIdUserAttributesPost200ResponseData
@@ -80,6 +80,11 @@ func (o UsersUserIdUserAttributesPost200ResponseData) MarshalJSON() ([]byte, err
 func (o UsersUserIdUserAttributesPost200ResponseData) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["metadata"] = o.Metadata
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -107,15 +112,20 @@ func (o *UsersUserIdUserAttributesPost200ResponseData) UnmarshalJSON(data []byte
 
 	varUsersUserIdUserAttributesPost200ResponseData := _UsersUserIdUserAttributesPost200ResponseData{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUsersUserIdUserAttributesPost200ResponseData)
+	err = json.Unmarshal(data, &varUsersUserIdUserAttributesPost200ResponseData)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UsersUserIdUserAttributesPost200ResponseData(varUsersUserIdUserAttributesPost200ResponseData)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "metadata")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__users_get_200_response.go
+++ b/internal/sdk/api/model__users_get_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type UsersGet200Response struct {
 	NextToken NullableString `json:"next_token"`
 	// Whether there are more items in the collection
 	HasMore bool `json:"has_more"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UsersGet200Response UsersGet200Response
@@ -194,6 +194,11 @@ func (o UsersGet200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize["total_count"] = o.TotalCount
 	toSerialize["next_token"] = o.NextToken.Get()
 	toSerialize["has_more"] = o.HasMore
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *UsersGet200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varUsersGet200Response := _UsersGet200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUsersGet200Response)
+	err = json.Unmarshal(data, &varUsersGet200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UsersGet200Response(varUsersGet200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "next_token")
+		delete(additionalProperties, "has_more")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model__users_post_200_response.go
+++ b/internal/sdk/api/model__users_post_200_response.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type UsersPost200Response struct {
 	// API request succeeded
 	Success bool `json:"success"`
 	Data UsersPost200ResponseData `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UsersPost200Response UsersPost200Response
@@ -107,6 +107,11 @@ func (o UsersPost200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *UsersPost200Response) UnmarshalJSON(data []byte) (err error) {
 
 	varUsersPost200Response := _UsersPost200Response{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUsersPost200Response)
+	err = json.Unmarshal(data, &varUsersPost200Response)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UsersPost200Response(varUsersPost200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model_access_request.go
+++ b/internal/sdk/api/model_access_request.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type AccessRequest struct {
 	LegacyId float32 `json:"legacy_id"`
 	RequestingEmail string `json:"requesting_email"`
 	UpdatedById NullableString `json:"updated_by_id"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AccessRequest AccessRequest
@@ -189,6 +189,11 @@ func (o AccessRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize["legacy_id"] = o.LegacyId
 	toSerialize["requesting_email"] = o.RequestingEmail
 	toSerialize["updated_by_id"] = o.UpdatedById.Get()
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -220,15 +225,24 @@ func (o *AccessRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varAccessRequest := _AccessRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAccessRequest)
+	err = json.Unmarshal(data, &varAccessRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AccessRequest(varAccessRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "requesting_email")
+		delete(additionalProperties, "updated_by_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model_app.go
+++ b/internal/sdk/api/model_app.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -39,6 +38,7 @@ type App struct {
 	IsModule bool `json:"is_module"`
 	// Whether the App is a mobile app
 	IsMobileApp bool `json:"is_mobile_app"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _App App
@@ -308,6 +308,11 @@ func (o App) ToMap() (map[string]interface{}, error) {
 	toSerialize["shortlink"] = o.Shortlink.Get()
 	toSerialize["is_module"] = o.IsModule
 	toSerialize["is_mobile_app"] = o.IsMobileApp
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -343,15 +348,28 @@ func (o *App) UnmarshalJSON(data []byte) (err error) {
 
 	varApp := _App{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varApp)
+	err = json.Unmarshal(data, &varApp)
 
 	if err != nil {
 		return err
 	}
 
 	*o = App(varApp)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "folder_id")
+		delete(additionalProperties, "protected")
+		delete(additionalProperties, "synced")
+		delete(additionalProperties, "shortlink")
+		delete(additionalProperties, "is_module")
+		delete(additionalProperties, "is_mobile_app")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model_app_theme.go
+++ b/internal/sdk/api/model_app_theme.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -27,6 +26,7 @@ type AppTheme struct {
 	Name string `json:"name"`
 	// The theme object.
 	Theme map[string]interface{} `json:"theme"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AppTheme AppTheme
@@ -162,6 +162,11 @@ func (o AppTheme) ToMap() (map[string]interface{}, error) {
 	toSerialize["legacy_id"] = o.LegacyId
 	toSerialize["name"] = o.Name
 	toSerialize["theme"] = o.Theme
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -192,15 +197,23 @@ func (o *AppTheme) UnmarshalJSON(data []byte) (err error) {
 
 	varAppTheme := _AppTheme{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAppTheme)
+	err = json.Unmarshal(data, &varAppTheme)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AppTheme(varAppTheme)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "theme")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model_configuration_variable.go
+++ b/internal/sdk/api/model_configuration_variable.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -30,6 +29,7 @@ type ConfigurationVariable struct {
 	// Whether the configuration variable is a secret
 	Secret bool `json:"secret"`
 	Values []ConfigurationVariablesGet200ResponseDataInnerValuesInner `json:"values"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ConfigurationVariable ConfigurationVariable
@@ -200,6 +200,11 @@ func (o ConfigurationVariable) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["secret"] = o.Secret
 	toSerialize["values"] = o.Values
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -230,15 +235,24 @@ func (o *ConfigurationVariable) UnmarshalJSON(data []byte) (err error) {
 
 	varConfigurationVariable := _ConfigurationVariable{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varConfigurationVariable)
+	err = json.Unmarshal(data, &varConfigurationVariable)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ConfigurationVariable(varConfigurationVariable)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "secret")
+		delete(additionalProperties, "values")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model_custom_component_library.go
+++ b/internal/sdk/api/model_custom_component_library.go
@@ -13,7 +13,6 @@ package api
 import (
 	"encoding/json"
 	"time"
-	"bytes"
 	"fmt"
 )
 
@@ -30,6 +29,7 @@ type CustomComponentLibrary struct {
 	Label string `json:"label"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CustomComponentLibrary CustomComponentLibrary
@@ -219,6 +219,11 @@ func (o CustomComponentLibrary) ToMap() (map[string]interface{}, error) {
 	toSerialize["label"] = o.Label
 	toSerialize["created_at"] = o.CreatedAt
 	toSerialize["updated_at"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -251,15 +256,25 @@ func (o *CustomComponentLibrary) UnmarshalJSON(data []byte) (err error) {
 
 	varCustomComponentLibrary := _CustomComponentLibrary{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCustomComponentLibrary)
+	err = json.Unmarshal(data, &varCustomComponentLibrary)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CustomComponentLibrary(varCustomComponentLibrary)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "label")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model_custom_component_library_revision.go
+++ b/internal/sdk/api/model_custom_component_library_revision.go
@@ -13,7 +13,6 @@ package api
 import (
 	"encoding/json"
 	"time"
-	"bytes"
 	"fmt"
 )
 
@@ -27,6 +26,7 @@ type CustomComponentLibraryRevision struct {
 	CustomComponentLibraryId string `json:"custom_component_library_id"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CustomComponentLibraryRevision CustomComponentLibraryRevision
@@ -188,6 +188,11 @@ func (o CustomComponentLibraryRevision) ToMap() (map[string]interface{}, error) 
 	toSerialize["custom_component_library_id"] = o.CustomComponentLibraryId
 	toSerialize["created_at"] = o.CreatedAt
 	toSerialize["updated_at"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -219,15 +224,24 @@ func (o *CustomComponentLibraryRevision) UnmarshalJSON(data []byte) (err error) 
 
 	varCustomComponentLibraryRevision := _CustomComponentLibraryRevision{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCustomComponentLibraryRevision)
+	err = json.Unmarshal(data, &varCustomComponentLibraryRevision)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CustomComponentLibraryRevision(varCustomComponentLibraryRevision)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "version")
+		delete(additionalProperties, "custom_component_library_id")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model_custom_component_library_revision_file.go
+++ b/internal/sdk/api/model_custom_component_library_revision_file.go
@@ -13,7 +13,6 @@ package api
 import (
 	"encoding/json"
 	"time"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type CustomComponentLibraryRevisionFile struct {
 	FileContents string `json:"file_contents"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CustomComponentLibraryRevisionFile CustomComponentLibraryRevisionFile
@@ -161,6 +161,11 @@ func (o CustomComponentLibraryRevisionFile) ToMap() (map[string]interface{}, err
 	toSerialize["file_contents"] = o.FileContents
 	toSerialize["created_at"] = o.CreatedAt
 	toSerialize["updated_at"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -191,15 +196,23 @@ func (o *CustomComponentLibraryRevisionFile) UnmarshalJSON(data []byte) (err err
 
 	varCustomComponentLibraryRevisionFile := _CustomComponentLibraryRevisionFile{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCustomComponentLibraryRevisionFile)
+	err = json.Unmarshal(data, &varCustomComponentLibraryRevisionFile)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CustomComponentLibraryRevisionFile(varCustomComponentLibraryRevisionFile)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "filepath")
+		delete(additionalProperties, "file_contents")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model_environment.go
+++ b/internal/sdk/api/model_environment.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -28,6 +27,7 @@ type Environment struct {
 	Default bool `json:"default"`
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Environment Environment
@@ -243,6 +243,11 @@ func (o Environment) ToMap() (map[string]interface{}, error) {
 	toSerialize["default"] = o.Default
 	toSerialize["created_at"] = o.CreatedAt
 	toSerialize["updated_at"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -276,15 +281,26 @@ func (o *Environment) UnmarshalJSON(data []byte) (err error) {
 
 	varEnvironment := _Environment{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varEnvironment)
+	err = json.Unmarshal(data, &varEnvironment)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Environment(varEnvironment)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "color")
+		delete(additionalProperties, "default")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model_folder.go
+++ b/internal/sdk/api/model_folder.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -33,6 +32,7 @@ type Folder struct {
 	IsSystemFolder bool `json:"is_system_folder"`
 	// The type of the folder
 	FolderType string `json:"folder_type"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Folder Folder
@@ -239,6 +239,11 @@ func (o Folder) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["is_system_folder"] = o.IsSystemFolder
 	toSerialize["folder_type"] = o.FolderType
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -270,15 +275,25 @@ func (o *Folder) UnmarshalJSON(data []byte) (err error) {
 
 	varFolder := _Folder{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFolder)
+	err = json.Unmarshal(data, &varFolder)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Folder(varFolder)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "parent_folder_id")
+		delete(additionalProperties, "is_system_folder")
+		delete(additionalProperties, "folder_type")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model_group.go
+++ b/internal/sdk/api/model_group.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -49,6 +48,7 @@ type Group struct {
 	AccountDetailsAccess bool `json:"account_details_access"`
 	// The app ID of the landing page
 	LandingPageAppId NullableString `json:"landing_page_app_id"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Group Group
@@ -450,6 +450,11 @@ func (o Group) ToMap() (map[string]interface{}, error) {
 	toSerialize["usage_analytics_access"] = o.UsageAnalyticsAccess
 	toSerialize["account_details_access"] = o.AccountDetailsAccess
 	toSerialize["landing_page_app_id"] = o.LandingPageAppId.Get()
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -490,15 +495,33 @@ func (o *Group) UnmarshalJSON(data []byte) (err error) {
 
 	varGroup := _Group{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGroup)
+	err = json.Unmarshal(data, &varGroup)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Group(varGroup)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "members")
+		delete(additionalProperties, "universal_app_access")
+		delete(additionalProperties, "universal_resource_access")
+		delete(additionalProperties, "universal_workflow_access")
+		delete(additionalProperties, "user_invites")
+		delete(additionalProperties, "user_list_access")
+		delete(additionalProperties, "audit_log_access")
+		delete(additionalProperties, "unpublished_release_access")
+		delete(additionalProperties, "usage_analytics_access")
+		delete(additionalProperties, "account_details_access")
+		delete(additionalProperties, "landing_page_app_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model_source_control_settings.go
+++ b/internal/sdk/api/model_source_control_settings.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -29,6 +28,7 @@ type SourceControlSettings struct {
 	CustomPullRequestTemplate string `json:"custom_pull_request_template"`
 	// When set to true, creates a read-only instance of Retool, where app editing is disabled. Defaults to false.
 	VersionControlLocked bool `json:"version_control_locked"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SourceControlSettings SourceControlSettings
@@ -164,6 +164,11 @@ func (o SourceControlSettings) ToMap() (map[string]interface{}, error) {
 	toSerialize["custom_pull_request_template_enabled"] = o.CustomPullRequestTemplateEnabled
 	toSerialize["custom_pull_request_template"] = o.CustomPullRequestTemplate
 	toSerialize["version_control_locked"] = o.VersionControlLocked
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -194,15 +199,23 @@ func (o *SourceControlSettings) UnmarshalJSON(data []byte) (err error) {
 
 	varSourceControlSettings := _SourceControlSettings{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSourceControlSettings)
+	err = json.Unmarshal(data, &varSourceControlSettings)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SourceControlSettings(varSourceControlSettings)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "auto_branch_naming_enabled")
+		delete(additionalProperties, "custom_pull_request_template_enabled")
+		delete(additionalProperties, "custom_pull_request_template")
+		delete(additionalProperties, "version_control_locked")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model_user_attributes.go
+++ b/internal/sdk/api/model_user_attributes.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -33,6 +32,7 @@ type UserAttributes struct {
 	DefaultValue NullableString `json:"default_value"`
 	// The name of the Intercom user attribute that this attribute should be mapped to
 	IntercomAttributeName NullableString `json:"intercom_attribute_name"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UserAttributes UserAttributes
@@ -224,6 +224,11 @@ func (o UserAttributes) ToMap() (map[string]interface{}, error) {
 	toSerialize["data_type"] = o.DataType
 	toSerialize["default_value"] = o.DefaultValue.Get()
 	toSerialize["intercom_attribute_name"] = o.IntercomAttributeName.Get()
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -256,15 +261,25 @@ func (o *UserAttributes) UnmarshalJSON(data []byte) (err error) {
 
 	varUserAttributes := _UserAttributes{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUserAttributes)
+	err = json.Unmarshal(data, &varUserAttributes)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UserAttributes(varUserAttributes)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "label")
+		delete(additionalProperties, "data_type")
+		delete(additionalProperties, "default_value")
+		delete(additionalProperties, "intercom_attribute_name")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/api/model_user_invite.go
+++ b/internal/sdk/api/model_user_invite.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -32,6 +31,7 @@ type UserInvite struct {
 	Metadata map[string]interface{} `json:"metadata"`
 	CreatedAt string `json:"created_at"`
 	InviteLink *string `json:"invite_link,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UserInvite UserInvite
@@ -368,6 +368,11 @@ func (o UserInvite) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.InviteLink) {
 		toSerialize["invite_link"] = o.InviteLink
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -404,15 +409,30 @@ func (o *UserInvite) UnmarshalJSON(data []byte) (err error) {
 
 	varUserInvite := _UserInvite{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUserInvite)
+	err = json.Unmarshal(data, &varUserInvite)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UserInvite(varUserInvite)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy_id")
+		delete(additionalProperties, "invited_by")
+		delete(additionalProperties, "invited_email")
+		delete(additionalProperties, "expires_at")
+		delete(additionalProperties, "claimed_by")
+		delete(additionalProperties, "claimed_at")
+		delete(additionalProperties, "user_type")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "invite_link")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/internal/sdk/generatorConfig.yaml
+++ b/internal/sdk/generatorConfig.yaml
@@ -1,2 +1,3 @@
 packageName: api
 withGoMod: false
+disallowAdditionalPropertiesIfNotPresent: false


### PR DESCRIPTION
### Description
It turns out our code-gened Go client for Retool API doesn't like unknown properties in Retool API responses. Which is absolutely not we want, since we want the client to be forward-compatible. This change updates the code-gen configuration to make it ignore unknown properties, and re-generates all the client files. So, despite the PR being 2k+ lines, the only change that matters is in the `generatorConfig.yaml` file.

### Tests
```
make test-unit
make test-acc-replay
```