### PR TITLE
[feat] Enforce minimal Retool version in the Terraform provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.8.0
 	github.com/stretchr/testify v1.8.2
+	golang.org/x/mod v0.17.0
 	gopkg.in/dnaeon/go-vcr.v3 v3.2.0
 )
 
@@ -74,7 +75,6 @@ require (
 	go.abhg.dev/goldmark/frontmatter v0.2.0 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df // indirect
-	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/text v0.15.0 // indirect


### PR DESCRIPTION
### Description
Adding a check to provider initialization that will error out if user's Retool version is too old. 
The check doesn't attempt to handle edge releases for now (e.g. it's possible to have situation in the future where we'll require 3.xx-stable or 3.yy-edge, where xx < yy).

### Tests
Manually tested and verified both "Retool version is fine" and "Retool version is too old" scenarios.