### PR TITLE
[feat] Add an ability to import permissions, source control and sso resources

### DIFF
--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -62,4 +62,11 @@ Required:
 - `id` (String) The ID of the subject.
 - `type` (String) The type of the subject - user or group.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# Permissions can be imported by specifying id in the format of subject_type|subject_id
+terraform import retool_permissions.example "group|123"
+```

--- a/docs/resources/source_control.md
+++ b/docs/resources/source_control.md
@@ -112,4 +112,11 @@ Required:
 - `project_id` (String) The numerical project ID for your GitLab project. Find this ID listed below the project's name on the project's homepage.
 - `url` (String) Your base GitLab URL. On GitLab Cloud, this is always https://gitlab.com. On GitLab self-managed, this is the URL where your instance is hosted.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# Source Control configuration can be imported by specifying arbitrary string id
+terraform import retool_source_control.example dummy_id
+```

--- a/docs/resources/source_control_settings.md
+++ b/docs/resources/source_control_settings.md
@@ -29,4 +29,11 @@ resource "retool_source_control_settings" "scm_settings" {
 - `custom_pull_request_template_enabled` (Boolean) When enabled, Retool will use the template specified to create pull requests. Defaults to false.
 - `version_control_locked` (Boolean) When set to true, creates a read-only instance of Retool, where app editing is disabled. Defaults to false.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# Source Control Settings can be imported by specifying arbitrary string id
+terraform import retool_source_control_settings.example dummy_id
+```

--- a/docs/resources/sso.md
+++ b/docs/resources/sso.md
@@ -131,4 +131,11 @@ Read-Only:
 - `encrypted_server_certificate` (String, Sensitive) Encrypted Server Certificate
 - `encrypted_server_key` (String, Sensitive) Encrypted Server Key
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# SSO configuration can be imported by specifying arbitrary string id
+terraform import retool_source_control.example dummy_id
+```

--- a/docs/resources/sso.md
+++ b/docs/resources/sso.md
@@ -137,5 +137,5 @@ Import is supported using the following syntax:
 
 ```shell
 # SSO configuration can be imported by specifying arbitrary string id
-terraform import retool_source_control.example dummy_id
+terraform import retool_sso.example dummy_id
 ```

--- a/examples/provider-initialization/main.tf
+++ b/examples/provider-initialization/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     retool = {
-      source = "registry.terraform.io/retool/retool"
+      source = "tryretool/retool"
     }
   }
 }

--- a/examples/resources/retool_permissions/import.sh
+++ b/examples/resources/retool_permissions/import.sh
@@ -1,0 +1,2 @@
+# Permissions can be imported by specifying id in the format of subject_type|subject_id
+terraform import retool_permissions.example "group|123"

--- a/examples/resources/retool_source_control/import.sh
+++ b/examples/resources/retool_source_control/import.sh
@@ -1,0 +1,2 @@
+# Source Control configuration can be imported by specifying arbitrary string id
+terraform import retool_source_control.example dummy_id

--- a/examples/resources/retool_source_control_settings/import.sh
+++ b/examples/resources/retool_source_control_settings/import.sh
@@ -1,0 +1,2 @@
+# Source Control Settings can be imported by specifying arbitrary string id
+terraform import retool_source_control_settings.example dummy_id

--- a/examples/resources/retool_sso/import.sh
+++ b/examples/resources/retool_sso/import.sh
@@ -1,2 +1,2 @@
 # SSO configuration can be imported by specifying arbitrary string id
-terraform import retool_source_control.example dummy_id
+terraform import retool_sso.example dummy_id

--- a/examples/resources/retool_sso/import.sh
+++ b/examples/resources/retool_sso/import.sh
@@ -1,0 +1,2 @@
+# SSO configuration can be imported by specifying arbitrary string id
+terraform import retool_source_control.example dummy_id

--- a/internal/provider/permissions/resource_test.go
+++ b/internal/provider/permissions/resource_test.go
@@ -81,7 +81,7 @@ func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
 
-func importStateIdFunc(state *terraform.State) (string, error) {
+func importStateIDFunc(state *terraform.State) (string, error) {
 	permissions, ok := state.RootModule().Resources["retool_permissions.test_permissions"]
 	if !ok {
 		return "", fmt.Errorf("Resource not found")
@@ -107,7 +107,7 @@ func TestAccPermissions(t *testing.T) {
 			// Import state.
 			{
 				ResourceName:                         "retool_permissions.test_permissions",
-				ImportStateIdFunc:                    importStateIdFunc,
+				ImportStateIdFunc:                    importStateIDFunc,
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "subject.id",

--- a/internal/provider/sourcecontrol/resource.go
+++ b/internal/provider/sourcecontrol/resource.go
@@ -22,8 +22,9 @@ import (
 
 // Ensure sourceControlResource implements the tfsdk.Resource interface.
 var (
-	_ resource.Resource              = &sourceControlResource{}
-	_ resource.ResourceWithConfigure = &sourceControlResource{}
+	_ resource.Resource                = &sourceControlResource{}
+	_ resource.ResourceWithConfigure   = &sourceControlResource{}
+	_ resource.ResourceWithImportState = &sourceControlResource{}
 )
 
 type sourceControlResource struct {
@@ -747,4 +748,17 @@ func (r *sourceControlResource) Delete(ctx context.Context, _ resource.DeleteReq
 		tflog.Error(ctx, "Error Deleting Source Control Config", utils.AddHTTPStatusCode(map[string]any{"error": err.Error()}, httpResponse))
 		return
 	}
+}
+
+// Import Source Control config.
+func (r *sourceControlResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	emptyModel := sourceControlModel{
+		GitHub:        types.ObjectNull(githubConfigModel{}.attributeTypes()),
+		GitLab:        types.ObjectNull(gitlabConfigModel{}.attributeTypes()),
+		AWSCodeCommit: types.ObjectNull(awsCodeCommitConfigModel{}.attributeTypes()),
+		Bitbucket:     types.ObjectNull(bitbucketConfigModel{}.attributeTypes()),
+		AzureRepos:    types.ObjectNull(azureReposConfigModel{}.attributeTypes()),
+	}
+	diags := resp.State.Set(ctx, emptyModel)
+	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/sourcecontrol/resource.go
+++ b/internal/provider/sourcecontrol/resource.go
@@ -751,7 +751,7 @@ func (r *sourceControlResource) Delete(ctx context.Context, _ resource.DeleteReq
 }
 
 // Import Source Control config.
-func (r *sourceControlResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *sourceControlResource) ImportState(ctx context.Context, _ resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	emptyModel := sourceControlModel{
 		GitHub:        types.ObjectNull(githubConfigModel{}.attributeTypes()),
 		GitLab:        types.ObjectNull(gitlabConfigModel{}.attributeTypes()),

--- a/internal/provider/sourcecontrol/resource_test.go
+++ b/internal/provider/sourcecontrol/resource_test.go
@@ -125,7 +125,7 @@ func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
 
-func TestAccSourceControl(t *testing.T) {
+func TestAccSourceControlTest(t *testing.T) {
 	acctest.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			// Read and Create.
@@ -230,6 +230,14 @@ func TestAccSourceControl(t *testing.T) {
 					resource.TestCheckResourceAttr("retool_source_control.scm", "azure_repos.use_basic_auth", "false"),
 				),
 				ExpectNonEmptyPlan: true, // Because it'd want to refresh secret strings.
+			},
+			// Import state.
+			{
+				ResourceName:                         "retool_source_control.scm",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "org",
+				ImportStateVerifyIgnore:              []string{"azure_repos.personal_access_token"}, // This attribute is secret and is set to null on read.
 			},
 		},
 	})

--- a/internal/provider/sourcecontrolsettings/resource.go
+++ b/internal/provider/sourcecontrolsettings/resource.go
@@ -19,8 +19,9 @@ import (
 
 // Ensure SCM settings implements the tfsdk.Resource interface.
 var (
-	_ resource.Resource              = &scmSettingsResource{}
-	_ resource.ResourceWithConfigure = &scmSettingsResource{}
+	_ resource.Resource                = &scmSettingsResource{}
+	_ resource.ResourceWithConfigure   = &scmSettingsResource{}
+	_ resource.ResourceWithImportState = &scmSettingsResource{}
 )
 
 type scmSettingsResource struct {
@@ -209,4 +210,11 @@ func (r *scmSettingsResource) Delete(ctx context.Context, _ resource.DeleteReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
+}
+
+// Import Source Control settings.
+func (r *scmSettingsResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	emptyState := scmSettingsModel{} // We just need to set the state to an empty object. The actual import will then happen in the Read method.
+	diags := resp.State.Set(ctx, emptyState)
+	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/sourcecontrolsettings/resource.go
+++ b/internal/provider/sourcecontrolsettings/resource.go
@@ -213,7 +213,7 @@ func (r *scmSettingsResource) Delete(ctx context.Context, _ resource.DeleteReque
 }
 
 // Import Source Control settings.
-func (r *scmSettingsResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *scmSettingsResource) ImportState(ctx context.Context, _ resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	emptyState := scmSettingsModel{} // We just need to set the state to an empty object. The actual import will then happen in the Read method.
 	diags := resp.State.Set(ctx, emptyState)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/sourcecontrolsettings/resource_test.go
+++ b/internal/provider/sourcecontrolsettings/resource_test.go
@@ -52,6 +52,13 @@ func TestAccSourceControlSettings(t *testing.T) {
 					resource.TestCheckResourceAttr("retool_source_control_settings.scm_settings", "version_control_locked", "true"),
 				),
 			},
+			// Import state.
+			{
+				ResourceName:                         "retool_source_control_settings.scm_settings",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "version_control_locked",
+			},
 			// Update and Read.
 			{
 				Config: testSCMSettingsUpdated,

--- a/internal/provider/sso/resource.go
+++ b/internal/provider/sso/resource.go
@@ -1038,7 +1038,7 @@ func (r *ssoResource) Delete(ctx context.Context, _ resource.DeleteRequest, resp
 }
 
 // Import SSO config into the state.
-func (r *ssoResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *ssoResource) ImportState(ctx context.Context, _ resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	emptyState := ssoResourceModel{
 		Google: types.ObjectNull(googleConfigModel{}.attributeTypes()),
 		OIDC:   types.ObjectNull(oidcConfigModel{}.attributeTypes()),

--- a/internal/provider/sso/resource.go
+++ b/internal/provider/sso/resource.go
@@ -25,8 +25,9 @@ import (
 
 // Ensure SSOResource implements the tfsdk.Resource interface.
 var (
-	_ resource.Resource              = &ssoResource{}
-	_ resource.ResourceWithConfigure = &ssoResource{}
+	_ resource.Resource                = &ssoResource{}
+	_ resource.ResourceWithConfigure   = &ssoResource{}
+	_ resource.ResourceWithImportState = &ssoResource{}
 )
 
 // ssoResource schema structure.
@@ -1034,4 +1035,15 @@ func (r *ssoResource) Delete(ctx context.Context, _ resource.DeleteRequest, resp
 		tflog.Error(ctx, "Error Deleting SSO config", utils.AddHTTPStatusCode(map[string]any{"error": err.Error()}, httpResponse))
 		return
 	}
+}
+
+// Import SSO config into the state.
+func (r *ssoResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	emptyState := ssoResourceModel{
+		Google: types.ObjectNull(googleConfigModel{}.attributeTypes()),
+		OIDC:   types.ObjectNull(oidcConfigModel{}.attributeTypes()),
+		SAML:   types.ObjectNull(samlConfigModel{}.attributeTypes()),
+	} // We just need to set the state to an empty object. The actual import will then happen in the Read method.
+	diags := resp.State.Set(ctx, emptyState)
+	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/sso/resource_test.go
+++ b/internal/provider/sso/resource_test.go
@@ -295,6 +295,14 @@ func TestAccSSO(t *testing.T) {
 					resource.TestCheckResourceAttrSet("retool_sso.sso", "saml.ldap_config.encrypted_server_certificate"),
 				),
 			},
+			// Import state.
+			{
+				ResourceName:                         "retool_sso.sso",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "google.client_id",
+				ImportStateVerifyIgnore:              []string{"google.client_secret", "saml.ldap_config.server_certificate", "saml.ldap_config.server_key"}, // These attributes are secret and are set to null on read.
+			},
 			// Update and Read.
 			{
 				Config: testUpdatedGoogleSamlConfig,

--- a/main.go
+++ b/main.go
@@ -37,8 +37,7 @@ func main() {
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		// TODO(dzmitry.kishylau): Update this string with the published name of Retool provider.
-		Address: "registry.terraform.io/retool/retool",
+		Address: "registry.terraform.io/tryretool/retool",
 		Debug:   debug,
 	}
 

--- a/test/data/recordings/TestAccPermissions.yaml
+++ b/test/data/recordings/TestAccPermissions.yaml
@@ -34,7 +34,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 111.369375ms
+        duration: 109.052ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -64,13 +64,13 @@ interactions:
         trailer: {}
         content_length: 500
         uncompressed: false
-        body: '{"success":true,"data":{"id":56,"legacy_id":56,"name":"tf-acc-test-group","members":[],"universal_app_access":"none","universal_resource_access":"none","universal_workflow_access":"none","universal_query_library_access":"none","user_invites":[],"user_list_access":false,"audit_log_access":false,"unpublished_release_access":false,"usage_analytics_access":false,"account_details_access":false,"landing_page_app_id":null,"updated_at":"2024-08-10T00:37:46.982Z","created_at":"2024-08-10T00:37:46.982Z"}}'
+        body: '{"success":true,"data":{"id":61,"legacy_id":61,"name":"tf-acc-test-group","members":[],"universal_app_access":"none","universal_resource_access":"none","universal_workflow_access":"none","universal_query_library_access":"none","user_invites":[],"user_list_access":false,"audit_log_access":false,"unpublished_release_access":false,"usage_analytics_access":false,"account_details_access":false,"landing_page_app_id":null,"updated_at":"2024-08-19T22:56:52.609Z","created_at":"2024-08-19T22:56:52.609Z"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 121.965375ms
+        duration: 120.049083ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -100,13 +100,13 @@ interactions:
         trailer: {}
         content_length: 243
         uncompressed: false
-        body: '{"success":true,"data":{"id":"app_103","legacy_id":"app_103","name":"tf-acc-test-folder1","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-10T00:37:47.067Z","created_at":"2024-08-10T00:37:47.067Z"}}'
+        body: '{"success":true,"data":{"id":"app_114","legacy_id":"app_114","name":"tf-acc-test-folder1","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-19T22:56:52.703Z","created_at":"2024-08-19T22:56:52.703Z"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 106.003125ms
+        duration: 113.749917ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -119,7 +119,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"folder_type":"app","name":"tf-acc-test-folder2","parent_folder_id":"app_103"}
+            {"folder_type":"app","name":"tf-acc-test-folder2","parent_folder_id":"app_114"}
         form: {}
         headers:
             Content-Type:
@@ -136,13 +136,13 @@ interactions:
         trailer: {}
         content_length: 245
         uncompressed: false
-        body: '{"success":true,"data":{"id":"app_104","legacy_id":"app_104","name":"tf-acc-test-folder2","parent_folder_id":"app_103","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-10T00:37:47.213Z","created_at":"2024-08-10T00:37:47.213Z"}}'
+        body: '{"success":true,"data":{"id":"app_115","legacy_id":"app_115","name":"tf-acc-test-folder2","parent_folder_id":"app_114","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-19T22:56:52.823Z","created_at":"2024-08-19T22:56:52.823Z"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 156.639792ms
+        duration: 135.400208ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -155,7 +155,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"access_level":"use","object":{"id":"app_103","type":"folder"},"subject":{"id":56,"type":"group"}}
+            {"access_level":"use","object":{"id":"app_114","type":"folder"},"subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -172,13 +172,13 @@ interactions:
         trailer: {}
         content_length: 130
         uncompressed: false
-        body: '{"success":true,"data":[{"type":"folder","id":"app_103","access_level":"use"}],"total_count":1,"next_token":null,"has_more":false}'
+        body: '{"success":true,"data":[{"type":"folder","id":"app_114","access_level":"use"}],"total_count":1,"next_token":null,"has_more":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 167.419666ms
+        duration: 160.066625ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -195,7 +195,7 @@ interactions:
         headers:
             User-Agent:
                 - OpenAPI-Generator/1.0.0/go
-        url: https://recorded.retool.dev/api/v2/groups/56
+        url: https://recorded.retool.dev/api/v2/folders/app_114
         method: GET
       response:
         proto: HTTP/1.1
@@ -203,15 +203,15 @@ interactions:
         proto_minor: 1
         transfer_encoding: []
         trailer: {}
-        content_length: 500
+        content_length: 243
         uncompressed: false
-        body: '{"success":true,"data":{"id":56,"legacy_id":56,"name":"tf-acc-test-group","members":[],"universal_app_access":"none","universal_resource_access":"none","universal_workflow_access":"none","universal_query_library_access":"none","user_invites":[],"user_list_access":false,"audit_log_access":false,"unpublished_release_access":false,"usage_analytics_access":false,"account_details_access":false,"landing_page_app_id":null,"updated_at":"2024-08-10T00:37:46.982Z","created_at":"2024-08-10T00:37:46.982Z"}}'
+        body: '{"success":true,"data":{"id":"app_114","legacy_id":"app_114","name":"tf-acc-test-folder1","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-19T22:56:52.703Z","created_at":"2024-08-19T22:56:52.703Z"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 84.5865ms
+        duration: 84.4565ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -228,7 +228,7 @@ interactions:
         headers:
             User-Agent:
                 - OpenAPI-Generator/1.0.0/go
-        url: https://recorded.retool.dev/api/v2/folders/app_103
+        url: https://recorded.retool.dev/api/v2/groups/61
         method: GET
       response:
         proto: HTTP/1.1
@@ -236,15 +236,15 @@ interactions:
         proto_minor: 1
         transfer_encoding: []
         trailer: {}
-        content_length: 243
+        content_length: 500
         uncompressed: false
-        body: '{"success":true,"data":{"id":"app_103","legacy_id":"app_103","name":"tf-acc-test-folder1","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-10T00:37:47.067Z","created_at":"2024-08-10T00:37:47.067Z"}}'
+        body: '{"success":true,"data":{"id":61,"legacy_id":61,"name":"tf-acc-test-group","members":[],"universal_app_access":"none","universal_resource_access":"none","universal_workflow_access":"none","universal_query_library_access":"none","user_invites":[],"user_list_access":false,"audit_log_access":false,"unpublished_release_access":false,"usage_analytics_access":false,"account_details_access":false,"landing_page_app_id":null,"updated_at":"2024-08-19T22:56:52.609Z","created_at":"2024-08-19T22:56:52.609Z"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 84.832709ms
+        duration: 95.960375ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -272,13 +272,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"success":true,"data":[{"id":"app_1","legacy_id":"app_1","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"app","updated_at":"2023-11-11T00:41:17.316Z","created_at":"2023-11-11T00:41:17.316Z"},{"id":"app_103","legacy_id":"app_103","name":"tf-acc-test-folder1","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-10T00:37:47.067Z","created_at":"2024-08-10T00:37:47.067Z"},{"id":"app_104","legacy_id":"app_104","name":"tf-acc-test-folder2","parent_folder_id":"app_103","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-10T00:37:47.213Z","created_at":"2024-08-10T00:37:47.213Z"},{"id":"app_2","legacy_id":"app_2","name":"archive","parent_folder_id":"app_1","is_system_folder":true,"folder_type":"app","updated_at":"2023-11-11T00:41:17.319Z","created_at":"2023-11-11T00:41:17.319Z"},{"id":"app_6","legacy_id":"app_6","name":"Components","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2023-11-11T00:54:28.000Z","created_at":"2023-11-11T00:54:28.000Z"},{"id":"app_7","legacy_id":"app_7","name":"Navigation","parent_folder_id":"app_6","is_system_folder":false,"folder_type":"app","updated_at":"2023-11-11T00:54:28.579Z","created_at":"2023-11-11T00:54:28.579Z"},{"id":"file_5","legacy_id":"file_5","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"file","updated_at":"2023-11-11T00:41:17.328Z","created_at":"2023-11-11T00:41:17.328Z"},{"id":"resource_1","legacy_id":"resource_1","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"resource","updated_at":"2023-11-11T00:41:17.321Z","created_at":"2023-11-11T00:41:17.321Z"},{"id":"resource_2","legacy_id":"resource_2","name":"sample","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:41:18.336Z","created_at":"2023-11-11T00:41:18.336Z"},{"id":"resource_3","legacy_id":"resource_3","name":"dev","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:54:22.753Z","created_at":"2023-11-11T00:54:22.753Z"},{"id":"resource_4","legacy_id":"resource_4","name":"shared","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:54:23.102Z","created_at":"2023-11-11T00:54:23.102Z"},{"id":"workflow_3","legacy_id":"workflow_3","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"workflow","updated_at":"2023-11-11T00:41:17.324Z","created_at":"2023-11-11T00:41:17.324Z"},{"id":"workflow_4","legacy_id":"workflow_4","name":"archive","parent_folder_id":"workflow_3","is_system_folder":true,"folder_type":"workflow","updated_at":"2023-11-11T00:41:17.326Z","created_at":"2023-11-11T00:41:17.326Z"}],"total_count":13,"next_token":null,"has_more":false}'
+        body: '{"success":true,"data":[{"id":"app_1","legacy_id":"app_1","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"app","updated_at":"2023-11-11T00:41:17.316Z","created_at":"2023-11-11T00:41:17.316Z"},{"id":"app_114","legacy_id":"app_114","name":"tf-acc-test-folder1","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-19T22:56:52.703Z","created_at":"2024-08-19T22:56:52.703Z"},{"id":"app_115","legacy_id":"app_115","name":"tf-acc-test-folder2","parent_folder_id":"app_114","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-19T22:56:52.823Z","created_at":"2024-08-19T22:56:52.823Z"},{"id":"app_2","legacy_id":"app_2","name":"archive","parent_folder_id":"app_1","is_system_folder":true,"folder_type":"app","updated_at":"2023-11-11T00:41:17.319Z","created_at":"2023-11-11T00:41:17.319Z"},{"id":"app_6","legacy_id":"app_6","name":"Components","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2023-11-11T00:54:28.000Z","created_at":"2023-11-11T00:54:28.000Z"},{"id":"app_7","legacy_id":"app_7","name":"Navigation","parent_folder_id":"app_6","is_system_folder":false,"folder_type":"app","updated_at":"2023-11-11T00:54:28.579Z","created_at":"2023-11-11T00:54:28.579Z"},{"id":"file_5","legacy_id":"file_5","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"file","updated_at":"2023-11-11T00:41:17.328Z","created_at":"2023-11-11T00:41:17.328Z"},{"id":"resource_1","legacy_id":"resource_1","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"resource","updated_at":"2023-11-11T00:41:17.321Z","created_at":"2023-11-11T00:41:17.321Z"},{"id":"resource_2","legacy_id":"resource_2","name":"sample","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:41:18.336Z","created_at":"2023-11-11T00:41:18.336Z"},{"id":"resource_3","legacy_id":"resource_3","name":"dev","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:54:22.753Z","created_at":"2023-11-11T00:54:22.753Z"},{"id":"resource_4","legacy_id":"resource_4","name":"shared","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:54:23.102Z","created_at":"2023-11-11T00:54:23.102Z"},{"id":"workflow_3","legacy_id":"workflow_3","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"workflow","updated_at":"2023-11-11T00:41:17.324Z","created_at":"2023-11-11T00:41:17.324Z"},{"id":"workflow_4","legacy_id":"workflow_4","name":"archive","parent_folder_id":"workflow_3","is_system_folder":true,"folder_type":"workflow","updated_at":"2023-11-11T00:41:17.326Z","created_at":"2023-11-11T00:41:17.326Z"}],"total_count":13,"next_token":null,"has_more":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 73.0195ms
+        duration: 82.545083ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -295,7 +295,7 @@ interactions:
         headers:
             User-Agent:
                 - OpenAPI-Generator/1.0.0/go
-        url: https://recorded.retool.dev/api/v2/folders/app_104
+        url: https://recorded.retool.dev/api/v2/folders/app_115
         method: GET
       response:
         proto: HTTP/1.1
@@ -305,13 +305,13 @@ interactions:
         trailer: {}
         content_length: 245
         uncompressed: false
-        body: '{"success":true,"data":{"id":"app_104","legacy_id":"app_104","name":"tf-acc-test-folder2","parent_folder_id":"app_103","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-10T00:37:47.213Z","created_at":"2024-08-10T00:37:47.213Z"}}'
+        body: '{"success":true,"data":{"id":"app_115","legacy_id":"app_115","name":"tf-acc-test-folder2","parent_folder_id":"app_114","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-19T22:56:52.823Z","created_at":"2024-08-19T22:56:52.823Z"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 93.972875ms
+        duration: 85.777041ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -324,7 +324,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"object_type":"app","subject":{"id":56,"type":"group"}}
+            {"object_type":"app","subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -347,7 +347,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 110.223959ms
+        duration: 89.760167ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -360,7 +360,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"object_type":"folder","subject":{"id":56,"type":"group"}}
+            {"object_type":"folder","subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -377,13 +377,13 @@ interactions:
         trailer: {}
         content_length: 130
         uncompressed: false
-        body: '{"success":true,"data":[{"type":"folder","id":"app_103","access_level":"use"}],"total_count":1,"next_token":null,"has_more":false}'
+        body: '{"success":true,"data":[{"type":"folder","id":"app_114","access_level":"use"}],"total_count":1,"next_token":null,"has_more":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 107.517625ms
+        duration: 82.941959ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -396,7 +396,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"object_type":"resource","subject":{"id":56,"type":"group"}}
+            {"object_type":"resource","subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -419,7 +419,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 96.093708ms
+        duration: 80.39725ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -432,7 +432,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"object_type":"resource_configuration","subject":{"id":56,"type":"group"}}
+            {"object_type":"resource_configuration","subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -455,41 +455,152 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 108.428416ms
+        duration: 74.687084ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 57
         transfer_encoding: []
         trailer: {}
         host: recorded.retool.dev
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: |
+            {"object_type":"app","subject":{"id":61,"type":"group"}}
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
                 - OpenAPI-Generator/1.0.0/go
-        url: https://recorded.retool.dev/api/v2/groups/56
-        method: GET
+        url: https://recorded.retool.dev/api/v2/permissions/listObjects
+        method: POST
       response:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         transfer_encoding: []
         trailer: {}
-        content_length: 500
+        content_length: 77
         uncompressed: false
-        body: '{"success":true,"data":{"id":56,"legacy_id":56,"name":"tf-acc-test-group","members":[],"universal_app_access":"none","universal_resource_access":"none","universal_workflow_access":"none","universal_query_library_access":"none","user_invites":[],"user_list_access":false,"audit_log_access":false,"unpublished_release_access":false,"usage_analytics_access":false,"account_details_access":false,"landing_page_app_id":null,"updated_at":"2024-08-10T00:37:46.982Z","created_at":"2024-08-10T00:37:46.982Z"}}'
+        body: '{"success":true,"data":[],"total_count":0,"next_token":null,"has_more":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 89.251333ms
+        duration: 93.08675ms
     - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 60
+        transfer_encoding: []
+        trailer: {}
+        host: recorded.retool.dev
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"object_type":"folder","subject":{"id":61,"type":"group"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - OpenAPI-Generator/1.0.0/go
+        url: https://recorded.retool.dev/api/v2/permissions/listObjects
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 130
+        uncompressed: false
+        body: '{"success":true,"data":[{"type":"folder","id":"app_114","access_level":"use"}],"total_count":1,"next_token":null,"has_more":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 108.188209ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 62
+        transfer_encoding: []
+        trailer: {}
+        host: recorded.retool.dev
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"object_type":"resource","subject":{"id":61,"type":"group"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - OpenAPI-Generator/1.0.0/go
+        url: https://recorded.retool.dev/api/v2/permissions/listObjects
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 77
+        uncompressed: false
+        body: '{"success":true,"data":[],"total_count":0,"next_token":null,"has_more":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 95.26775ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 76
+        transfer_encoding: []
+        trailer: {}
+        host: recorded.retool.dev
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"object_type":"resource_configuration","subject":{"id":61,"type":"group"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - OpenAPI-Generator/1.0.0/go
+        url: https://recorded.retool.dev/api/v2/permissions/listObjects
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 77
+        uncompressed: false
+        body: '{"success":true,"data":[],"total_count":0,"next_token":null,"has_more":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 97.438166ms
+    - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -505,7 +616,7 @@ interactions:
         headers:
             User-Agent:
                 - OpenAPI-Generator/1.0.0/go
-        url: https://recorded.retool.dev/api/v2/folders/app_103
+        url: https://recorded.retool.dev/api/v2/folders/app_114
         method: GET
       response:
         proto: HTTP/1.1
@@ -515,14 +626,47 @@ interactions:
         trailer: {}
         content_length: 243
         uncompressed: false
-        body: '{"success":true,"data":{"id":"app_103","legacy_id":"app_103","name":"tf-acc-test-folder1","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-10T00:37:47.067Z","created_at":"2024-08-10T00:37:47.067Z"}}'
+        body: '{"success":true,"data":{"id":"app_114","legacy_id":"app_114","name":"tf-acc-test-folder1","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-19T22:56:52.703Z","created_at":"2024-08-19T22:56:52.703Z"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 89.544375ms
-    - id: 15
+        duration: 112.731417ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: recorded.retool.dev
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - OpenAPI-Generator/1.0.0/go
+        url: https://recorded.retool.dev/api/v2/groups/61
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 500
+        uncompressed: false
+        body: '{"success":true,"data":{"id":61,"legacy_id":61,"name":"tf-acc-test-group","members":[],"universal_app_access":"none","universal_resource_access":"none","universal_workflow_access":"none","universal_query_library_access":"none","user_invites":[],"user_list_access":false,"audit_log_access":false,"unpublished_release_access":false,"usage_analytics_access":false,"account_details_access":false,"landing_page_app_id":null,"updated_at":"2024-08-19T22:56:52.609Z","created_at":"2024-08-19T22:56:52.609Z"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 113.465292ms
+    - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -549,14 +693,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"success":true,"data":[{"id":"app_1","legacy_id":"app_1","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"app","updated_at":"2023-11-11T00:41:17.316Z","created_at":"2023-11-11T00:41:17.316Z"},{"id":"app_103","legacy_id":"app_103","name":"tf-acc-test-folder1","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-10T00:37:47.067Z","created_at":"2024-08-10T00:37:47.067Z"},{"id":"app_104","legacy_id":"app_104","name":"tf-acc-test-folder2","parent_folder_id":"app_103","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-10T00:37:47.213Z","created_at":"2024-08-10T00:37:47.213Z"},{"id":"app_2","legacy_id":"app_2","name":"archive","parent_folder_id":"app_1","is_system_folder":true,"folder_type":"app","updated_at":"2023-11-11T00:41:17.319Z","created_at":"2023-11-11T00:41:17.319Z"},{"id":"app_6","legacy_id":"app_6","name":"Components","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2023-11-11T00:54:28.000Z","created_at":"2023-11-11T00:54:28.000Z"},{"id":"app_7","legacy_id":"app_7","name":"Navigation","parent_folder_id":"app_6","is_system_folder":false,"folder_type":"app","updated_at":"2023-11-11T00:54:28.579Z","created_at":"2023-11-11T00:54:28.579Z"},{"id":"file_5","legacy_id":"file_5","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"file","updated_at":"2023-11-11T00:41:17.328Z","created_at":"2023-11-11T00:41:17.328Z"},{"id":"resource_1","legacy_id":"resource_1","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"resource","updated_at":"2023-11-11T00:41:17.321Z","created_at":"2023-11-11T00:41:17.321Z"},{"id":"resource_2","legacy_id":"resource_2","name":"sample","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:41:18.336Z","created_at":"2023-11-11T00:41:18.336Z"},{"id":"resource_3","legacy_id":"resource_3","name":"dev","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:54:22.753Z","created_at":"2023-11-11T00:54:22.753Z"},{"id":"resource_4","legacy_id":"resource_4","name":"shared","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:54:23.102Z","created_at":"2023-11-11T00:54:23.102Z"},{"id":"workflow_3","legacy_id":"workflow_3","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"workflow","updated_at":"2023-11-11T00:41:17.324Z","created_at":"2023-11-11T00:41:17.324Z"},{"id":"workflow_4","legacy_id":"workflow_4","name":"archive","parent_folder_id":"workflow_3","is_system_folder":true,"folder_type":"workflow","updated_at":"2023-11-11T00:41:17.326Z","created_at":"2023-11-11T00:41:17.326Z"}],"total_count":13,"next_token":null,"has_more":false}'
+        body: '{"success":true,"data":[{"id":"app_1","legacy_id":"app_1","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"app","updated_at":"2023-11-11T00:41:17.316Z","created_at":"2023-11-11T00:41:17.316Z"},{"id":"app_114","legacy_id":"app_114","name":"tf-acc-test-folder1","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-19T22:56:52.703Z","created_at":"2024-08-19T22:56:52.703Z"},{"id":"app_115","legacy_id":"app_115","name":"tf-acc-test-folder2","parent_folder_id":"app_114","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-19T22:56:52.823Z","created_at":"2024-08-19T22:56:52.823Z"},{"id":"app_2","legacy_id":"app_2","name":"archive","parent_folder_id":"app_1","is_system_folder":true,"folder_type":"app","updated_at":"2023-11-11T00:41:17.319Z","created_at":"2023-11-11T00:41:17.319Z"},{"id":"app_6","legacy_id":"app_6","name":"Components","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2023-11-11T00:54:28.000Z","created_at":"2023-11-11T00:54:28.000Z"},{"id":"app_7","legacy_id":"app_7","name":"Navigation","parent_folder_id":"app_6","is_system_folder":false,"folder_type":"app","updated_at":"2023-11-11T00:54:28.579Z","created_at":"2023-11-11T00:54:28.579Z"},{"id":"file_5","legacy_id":"file_5","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"file","updated_at":"2023-11-11T00:41:17.328Z","created_at":"2023-11-11T00:41:17.328Z"},{"id":"resource_1","legacy_id":"resource_1","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"resource","updated_at":"2023-11-11T00:41:17.321Z","created_at":"2023-11-11T00:41:17.321Z"},{"id":"resource_2","legacy_id":"resource_2","name":"sample","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:41:18.336Z","created_at":"2023-11-11T00:41:18.336Z"},{"id":"resource_3","legacy_id":"resource_3","name":"dev","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:54:22.753Z","created_at":"2023-11-11T00:54:22.753Z"},{"id":"resource_4","legacy_id":"resource_4","name":"shared","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:54:23.102Z","created_at":"2023-11-11T00:54:23.102Z"},{"id":"workflow_3","legacy_id":"workflow_3","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"workflow","updated_at":"2023-11-11T00:41:17.324Z","created_at":"2023-11-11T00:41:17.324Z"},{"id":"workflow_4","legacy_id":"workflow_4","name":"archive","parent_folder_id":"workflow_3","is_system_folder":true,"folder_type":"workflow","updated_at":"2023-11-11T00:41:17.326Z","created_at":"2023-11-11T00:41:17.326Z"}],"total_count":13,"next_token":null,"has_more":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 75.089792ms
-    - id: 16
+        duration: 88.184459ms
+    - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -572,7 +716,7 @@ interactions:
         headers:
             User-Agent:
                 - OpenAPI-Generator/1.0.0/go
-        url: https://recorded.retool.dev/api/v2/folders/app_104
+        url: https://recorded.retool.dev/api/v2/folders/app_115
         method: GET
       response:
         proto: HTTP/1.1
@@ -582,14 +726,14 @@ interactions:
         trailer: {}
         content_length: 245
         uncompressed: false
-        body: '{"success":true,"data":{"id":"app_104","legacy_id":"app_104","name":"tf-acc-test-folder2","parent_folder_id":"app_103","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-10T00:37:47.213Z","created_at":"2024-08-10T00:37:47.213Z"}}'
+        body: '{"success":true,"data":{"id":"app_115","legacy_id":"app_115","name":"tf-acc-test-folder2","parent_folder_id":"app_114","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-19T22:56:52.823Z","created_at":"2024-08-19T22:56:52.823Z"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 79.422916ms
-    - id: 17
+        duration: 76.49925ms
+    - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -601,7 +745,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"object_type":"app","subject":{"id":56,"type":"group"}}
+            {"object_type":"app","subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -624,8 +768,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 96.342709ms
-    - id: 18
+        duration: 85.388541ms
+    - id: 22
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -637,7 +781,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"object_type":"folder","subject":{"id":56,"type":"group"}}
+            {"object_type":"folder","subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -654,14 +798,14 @@ interactions:
         trailer: {}
         content_length: 130
         uncompressed: false
-        body: '{"success":true,"data":[{"type":"folder","id":"app_103","access_level":"use"}],"total_count":1,"next_token":null,"has_more":false}'
+        body: '{"success":true,"data":[{"type":"folder","id":"app_114","access_level":"use"}],"total_count":1,"next_token":null,"has_more":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 112.902292ms
-    - id: 19
+        duration: 118.806292ms
+    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -673,7 +817,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"object_type":"resource","subject":{"id":56,"type":"group"}}
+            {"object_type":"resource","subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -696,8 +840,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 95.040084ms
-    - id: 20
+        duration: 212.445375ms
+    - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -709,7 +853,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"object_type":"resource_configuration","subject":{"id":56,"type":"group"}}
+            {"object_type":"resource_configuration","subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -732,8 +876,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 77.60925ms
-    - id: 21
+        duration: 71.159875ms
+    - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -745,7 +889,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"object":{"id":"app_103","type":"folder"},"subject":{"id":56,"type":"group"}}
+            {"object":{"id":"app_114","type":"folder"},"subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -768,8 +912,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 139.267ms
-    - id: 22
+        duration: 166.442542ms
+    - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -781,7 +925,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"access_level":"own","object":{"id":"app_104","type":"folder"},"subject":{"id":56,"type":"group"}}
+            {"access_level":"own","object":{"id":"app_115","type":"folder"},"subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -798,14 +942,14 @@ interactions:
         trailer: {}
         content_length: 130
         uncompressed: false
-        body: '{"success":true,"data":[{"type":"folder","id":"app_104","access_level":"own"}],"total_count":1,"next_token":null,"has_more":false}'
+        body: '{"success":true,"data":[{"type":"folder","id":"app_115","access_level":"own"}],"total_count":1,"next_token":null,"has_more":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 151.30525ms
-    - id: 23
+        duration: 149.284875ms
+    - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -821,7 +965,7 @@ interactions:
         headers:
             User-Agent:
                 - OpenAPI-Generator/1.0.0/go
-        url: https://recorded.retool.dev/api/v2/groups/56
+        url: https://recorded.retool.dev/api/v2/groups/61
         method: GET
       response:
         proto: HTTP/1.1
@@ -831,14 +975,14 @@ interactions:
         trailer: {}
         content_length: 500
         uncompressed: false
-        body: '{"success":true,"data":{"id":56,"legacy_id":56,"name":"tf-acc-test-group","members":[],"universal_app_access":"none","universal_resource_access":"none","universal_workflow_access":"none","universal_query_library_access":"none","user_invites":[],"user_list_access":false,"audit_log_access":false,"unpublished_release_access":false,"usage_analytics_access":false,"account_details_access":false,"landing_page_app_id":null,"updated_at":"2024-08-10T00:37:46.982Z","created_at":"2024-08-10T00:37:46.982Z"}}'
+        body: '{"success":true,"data":{"id":61,"legacy_id":61,"name":"tf-acc-test-group","members":[],"universal_app_access":"none","universal_resource_access":"none","universal_workflow_access":"none","universal_query_library_access":"none","user_invites":[],"user_list_access":false,"audit_log_access":false,"unpublished_release_access":false,"usage_analytics_access":false,"account_details_access":false,"landing_page_app_id":null,"updated_at":"2024-08-19T22:56:52.609Z","created_at":"2024-08-19T22:56:52.609Z"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 86.697666ms
-    - id: 24
+        duration: 109.325208ms
+    - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -854,7 +998,7 @@ interactions:
         headers:
             User-Agent:
                 - OpenAPI-Generator/1.0.0/go
-        url: https://recorded.retool.dev/api/v2/folders/app_103
+        url: https://recorded.retool.dev/api/v2/folders/app_114
         method: GET
       response:
         proto: HTTP/1.1
@@ -864,14 +1008,14 @@ interactions:
         trailer: {}
         content_length: 243
         uncompressed: false
-        body: '{"success":true,"data":{"id":"app_103","legacy_id":"app_103","name":"tf-acc-test-folder1","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-10T00:37:47.067Z","created_at":"2024-08-10T00:37:47.067Z"}}'
+        body: '{"success":true,"data":{"id":"app_114","legacy_id":"app_114","name":"tf-acc-test-folder1","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-19T22:56:52.703Z","created_at":"2024-08-19T22:56:52.703Z"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 87.06775ms
-    - id: 25
+        duration: 109.770875ms
+    - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -898,14 +1042,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"success":true,"data":[{"id":"app_1","legacy_id":"app_1","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"app","updated_at":"2023-11-11T00:41:17.316Z","created_at":"2023-11-11T00:41:17.316Z"},{"id":"app_103","legacy_id":"app_103","name":"tf-acc-test-folder1","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-10T00:37:47.067Z","created_at":"2024-08-10T00:37:47.067Z"},{"id":"app_104","legacy_id":"app_104","name":"tf-acc-test-folder2","parent_folder_id":"app_103","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-10T00:37:47.213Z","created_at":"2024-08-10T00:37:47.213Z"},{"id":"app_2","legacy_id":"app_2","name":"archive","parent_folder_id":"app_1","is_system_folder":true,"folder_type":"app","updated_at":"2023-11-11T00:41:17.319Z","created_at":"2023-11-11T00:41:17.319Z"},{"id":"app_6","legacy_id":"app_6","name":"Components","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2023-11-11T00:54:28.000Z","created_at":"2023-11-11T00:54:28.000Z"},{"id":"app_7","legacy_id":"app_7","name":"Navigation","parent_folder_id":"app_6","is_system_folder":false,"folder_type":"app","updated_at":"2023-11-11T00:54:28.579Z","created_at":"2023-11-11T00:54:28.579Z"},{"id":"file_5","legacy_id":"file_5","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"file","updated_at":"2023-11-11T00:41:17.328Z","created_at":"2023-11-11T00:41:17.328Z"},{"id":"resource_1","legacy_id":"resource_1","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"resource","updated_at":"2023-11-11T00:41:17.321Z","created_at":"2023-11-11T00:41:17.321Z"},{"id":"resource_2","legacy_id":"resource_2","name":"sample","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:41:18.336Z","created_at":"2023-11-11T00:41:18.336Z"},{"id":"resource_3","legacy_id":"resource_3","name":"dev","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:54:22.753Z","created_at":"2023-11-11T00:54:22.753Z"},{"id":"resource_4","legacy_id":"resource_4","name":"shared","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:54:23.102Z","created_at":"2023-11-11T00:54:23.102Z"},{"id":"workflow_3","legacy_id":"workflow_3","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"workflow","updated_at":"2023-11-11T00:41:17.324Z","created_at":"2023-11-11T00:41:17.324Z"},{"id":"workflow_4","legacy_id":"workflow_4","name":"archive","parent_folder_id":"workflow_3","is_system_folder":true,"folder_type":"workflow","updated_at":"2023-11-11T00:41:17.326Z","created_at":"2023-11-11T00:41:17.326Z"}],"total_count":13,"next_token":null,"has_more":false}'
+        body: '{"success":true,"data":[{"id":"app_1","legacy_id":"app_1","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"app","updated_at":"2023-11-11T00:41:17.316Z","created_at":"2023-11-11T00:41:17.316Z"},{"id":"app_114","legacy_id":"app_114","name":"tf-acc-test-folder1","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-19T22:56:52.703Z","created_at":"2024-08-19T22:56:52.703Z"},{"id":"app_115","legacy_id":"app_115","name":"tf-acc-test-folder2","parent_folder_id":"app_114","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-19T22:56:52.823Z","created_at":"2024-08-19T22:56:52.823Z"},{"id":"app_2","legacy_id":"app_2","name":"archive","parent_folder_id":"app_1","is_system_folder":true,"folder_type":"app","updated_at":"2023-11-11T00:41:17.319Z","created_at":"2023-11-11T00:41:17.319Z"},{"id":"app_6","legacy_id":"app_6","name":"Components","parent_folder_id":"app_1","is_system_folder":false,"folder_type":"app","updated_at":"2023-11-11T00:54:28.000Z","created_at":"2023-11-11T00:54:28.000Z"},{"id":"app_7","legacy_id":"app_7","name":"Navigation","parent_folder_id":"app_6","is_system_folder":false,"folder_type":"app","updated_at":"2023-11-11T00:54:28.579Z","created_at":"2023-11-11T00:54:28.579Z"},{"id":"file_5","legacy_id":"file_5","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"file","updated_at":"2023-11-11T00:41:17.328Z","created_at":"2023-11-11T00:41:17.328Z"},{"id":"resource_1","legacy_id":"resource_1","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"resource","updated_at":"2023-11-11T00:41:17.321Z","created_at":"2023-11-11T00:41:17.321Z"},{"id":"resource_2","legacy_id":"resource_2","name":"sample","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:41:18.336Z","created_at":"2023-11-11T00:41:18.336Z"},{"id":"resource_3","legacy_id":"resource_3","name":"dev","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:54:22.753Z","created_at":"2023-11-11T00:54:22.753Z"},{"id":"resource_4","legacy_id":"resource_4","name":"shared","parent_folder_id":"resource_1","is_system_folder":false,"folder_type":"resource","updated_at":"2023-11-11T00:54:23.102Z","created_at":"2023-11-11T00:54:23.102Z"},{"id":"workflow_3","legacy_id":"workflow_3","name":"root","parent_folder_id":null,"is_system_folder":true,"folder_type":"workflow","updated_at":"2023-11-11T00:41:17.324Z","created_at":"2023-11-11T00:41:17.324Z"},{"id":"workflow_4","legacy_id":"workflow_4","name":"archive","parent_folder_id":"workflow_3","is_system_folder":true,"folder_type":"workflow","updated_at":"2023-11-11T00:41:17.326Z","created_at":"2023-11-11T00:41:17.326Z"}],"total_count":13,"next_token":null,"has_more":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 73.195541ms
-    - id: 26
+        duration: 86.605958ms
+    - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -921,7 +1065,7 @@ interactions:
         headers:
             User-Agent:
                 - OpenAPI-Generator/1.0.0/go
-        url: https://recorded.retool.dev/api/v2/folders/app_104
+        url: https://recorded.retool.dev/api/v2/folders/app_115
         method: GET
       response:
         proto: HTTP/1.1
@@ -931,14 +1075,14 @@ interactions:
         trailer: {}
         content_length: 245
         uncompressed: false
-        body: '{"success":true,"data":{"id":"app_104","legacy_id":"app_104","name":"tf-acc-test-folder2","parent_folder_id":"app_103","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-10T00:37:47.213Z","created_at":"2024-08-10T00:37:47.213Z"}}'
+        body: '{"success":true,"data":{"id":"app_115","legacy_id":"app_115","name":"tf-acc-test-folder2","parent_folder_id":"app_114","is_system_folder":false,"folder_type":"app","updated_at":"2024-08-19T22:56:52.823Z","created_at":"2024-08-19T22:56:52.823Z"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 85.08275ms
-    - id: 27
+        duration: 117.673208ms
+    - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -950,7 +1094,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"object_type":"app","subject":{"id":56,"type":"group"}}
+            {"object_type":"app","subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -973,8 +1117,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 93.849541ms
-    - id: 28
+        duration: 171.537042ms
+    - id: 32
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -986,7 +1130,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"object_type":"folder","subject":{"id":56,"type":"group"}}
+            {"object_type":"folder","subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -1003,14 +1147,14 @@ interactions:
         trailer: {}
         content_length: 130
         uncompressed: false
-        body: '{"success":true,"data":[{"type":"folder","id":"app_104","access_level":"own"}],"total_count":1,"next_token":null,"has_more":false}'
+        body: '{"success":true,"data":[{"type":"folder","id":"app_115","access_level":"own"}],"total_count":1,"next_token":null,"has_more":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 115.385875ms
-    - id: 29
+        duration: 102.752375ms
+    - id: 33
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1022,7 +1166,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"object_type":"resource","subject":{"id":56,"type":"group"}}
+            {"object_type":"resource","subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -1045,8 +1189,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 91.184167ms
-    - id: 30
+        duration: 110.660208ms
+    - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1058,7 +1202,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"object_type":"resource_configuration","subject":{"id":56,"type":"group"}}
+            {"object_type":"resource_configuration","subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -1081,8 +1225,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 88.873458ms
-    - id: 31
+        duration: 81.491875ms
+    - id: 35
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1094,7 +1238,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"object":{"id":"app_104","type":"folder"},"subject":{"id":56,"type":"group"}}
+            {"object":{"id":"app_115","type":"folder"},"subject":{"id":61,"type":"group"}}
         form: {}
         headers:
             Content-Type:
@@ -1117,8 +1261,39 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 140.93725ms
-    - id: 32
+        duration: 147.244292ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: recorded.retool.dev
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - OpenAPI-Generator/1.0.0/go
+        url: https://recorded.retool.dev/api/v2/groups/61
+        method: DELETE
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers: {}
+        status: 204 No Content
+        code: 204
+        duration: 99.017ms
+    - id: 37
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1137,7 +1312,7 @@ interactions:
                 - application/json
             User-Agent:
                 - OpenAPI-Generator/1.0.0/go
-        url: https://recorded.retool.dev/api/v2/folders/app_104
+        url: https://recorded.retool.dev/api/v2/folders/app_115
         method: DELETE
       response:
         proto: HTTP/1.1
@@ -1151,39 +1326,8 @@ interactions:
         headers: {}
         status: 204 No Content
         code: 204
-        duration: 109.026042ms
-    - id: 33
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: recorded.retool.dev
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - OpenAPI-Generator/1.0.0/go
-        url: https://recorded.retool.dev/api/v2/groups/56
-        method: DELETE
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers: {}
-        status: 204 No Content
-        code: 204
-        duration: 113.058875ms
-    - id: 34
+        duration: 109.039417ms
+    - id: 38
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1202,7 +1346,7 @@ interactions:
                 - application/json
             User-Agent:
                 - OpenAPI-Generator/1.0.0/go
-        url: https://recorded.retool.dev/api/v2/folders/app_103
+        url: https://recorded.retool.dev/api/v2/folders/app_114
         method: DELETE
       response:
         proto: HTTP/1.1
@@ -1216,4 +1360,4 @@ interactions:
         headers: {}
         status: 204 No Content
         code: 204
-        duration: 102.100458ms
+        duration: 95.774375ms

--- a/test/data/recordings/TestAccSSO.yaml
+++ b/test/data/recordings/TestAccSSO.yaml
@@ -36,7 +36,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 78.960208ms
+        duration: 75.633833ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 68.082708ms
+        duration: 67.791ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -102,7 +102,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 64.6505ms
+        duration: 69.680667ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -138,7 +138,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 66.145375ms
+        duration: 73.200417ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -171,7 +171,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 75.095458ms
+        duration: 77.578583ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -204,7 +204,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 66.517375ms
+        duration: 71.298333ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -240,7 +240,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 69.07325ms
+        duration: 70.839583ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -273,7 +273,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 68.416792ms
+        duration: 70.233542ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -306,7 +306,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 77.130542ms
+        duration: 65.245917ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -319,7 +319,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"data":{"config_type":"saml","disable_email_password_login":true,"idp_metadata_xml":"metadata_xml","jit_enabled":true,"ldap_base_domain_components":"dc=example,dc=com","ldap_role_mapping":"admin-\u003eadmin_group,user-\u003euser_group,user-\u003eanother_user_group","ldap_server_certificate":"server_cert","ldap_server_key":"server_key","ldap_server_name":"ldap.example.com","ldap_server_url":"ldap://example.com","ldap_sync_group_claims":true,"restricted_domain":"example.com,example.org","saml_first_name_attribute":"first_name","saml_groups_attribute":"groups","saml_last_name_attribute":"last_name","saml_sync_group_claims":true,"trigger_login_automatically":true}}
+            {"data":{"config_type":"saml","disable_email_password_login":true,"idp_metadata_xml":"metadata_xml","jit_enabled":true,"ldap_base_domain_components":"dc=example,dc=com","ldap_role_mapping":"user-\u003euser_group,user-\u003eanother_user_group,admin-\u003eadmin_group","ldap_server_certificate":"server_cert","ldap_server_key":"server_key","ldap_server_name":"ldap.example.com","ldap_server_url":"ldap://example.com","ldap_sync_group_claims":true,"restricted_domain":"example.com,example.org","saml_first_name_attribute":"first_name","saml_groups_attribute":"groups","saml_last_name_attribute":"last_name","saml_sync_group_claims":true,"trigger_login_automatically":true}}
         form: {}
         headers:
             Content-Type:
@@ -336,13 +336,13 @@ interactions:
         trailer: {}
         content_length: 757
         uncompressed: false
-        body: '{"success":true,"data":{"config_type":"saml","saml_first_name_attribute":"first_name","saml_last_name_attribute":"last_name","saml_groups_attribute":"groups","saml_sync_group_claims":true,"ldap_sync_group_claims":true,"ldap_role_mapping":"admin->admin_group,user->user_group,user->another_user_group","ldap_server_url":"ldap://example.com","ldap_base_domain_components":"dc=example,dc=com","ldap_server_name":"ldap.example.com","ldap_server_key":"__RETOOL_ENCRYPTED__(7a08f5924114b5646723610a16e7710d)","ldap_server_certificate":"__RETOOL_ENCRYPTED__(28d15d7f8ebcb352f48f3295057cfb22)","restricted_domain":"example.com,example.org","trigger_login_automatically":true,"idp_metadata_xml":"metadata_xml","jit_enabled":true,"disable_email_password_login":true}}'
+        body: '{"success":true,"data":{"config_type":"saml","saml_first_name_attribute":"first_name","saml_last_name_attribute":"last_name","saml_groups_attribute":"groups","saml_sync_group_claims":true,"ldap_sync_group_claims":true,"ldap_role_mapping":"user->user_group,user->another_user_group,admin->admin_group","ldap_server_url":"ldap://example.com","ldap_base_domain_components":"dc=example,dc=com","ldap_server_name":"ldap.example.com","ldap_server_key":"__RETOOL_ENCRYPTED__(7a08f5924114b5646723610a16e7710d)","ldap_server_certificate":"__RETOOL_ENCRYPTED__(28d15d7f8ebcb352f48f3295057cfb22)","restricted_domain":"example.com,example.org","trigger_login_automatically":true,"idp_metadata_xml":"metadata_xml","jit_enabled":true,"disable_email_password_login":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 70.918167ms
+        duration: 67.210708ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -369,13 +369,13 @@ interactions:
         trailer: {}
         content_length: 757
         uncompressed: false
-        body: '{"success":true,"data":{"config_type":"saml","saml_first_name_attribute":"first_name","saml_last_name_attribute":"last_name","saml_groups_attribute":"groups","saml_sync_group_claims":true,"ldap_sync_group_claims":true,"ldap_role_mapping":"admin->admin_group,user->user_group,user->another_user_group","ldap_server_url":"ldap://example.com","ldap_base_domain_components":"dc=example,dc=com","ldap_server_name":"ldap.example.com","ldap_server_key":"__RETOOL_ENCRYPTED__(7a08f5924114b5646723610a16e7710d)","ldap_server_certificate":"__RETOOL_ENCRYPTED__(28d15d7f8ebcb352f48f3295057cfb22)","restricted_domain":"example.com,example.org","trigger_login_automatically":true,"idp_metadata_xml":"metadata_xml","jit_enabled":true,"disable_email_password_login":true}}'
+        body: '{"success":true,"data":{"config_type":"saml","saml_first_name_attribute":"first_name","saml_last_name_attribute":"last_name","saml_groups_attribute":"groups","saml_sync_group_claims":true,"ldap_sync_group_claims":true,"ldap_role_mapping":"user->user_group,user->another_user_group,admin->admin_group","ldap_server_url":"ldap://example.com","ldap_base_domain_components":"dc=example,dc=com","ldap_server_name":"ldap.example.com","ldap_server_key":"__RETOOL_ENCRYPTED__(7a08f5924114b5646723610a16e7710d)","ldap_server_certificate":"__RETOOL_ENCRYPTED__(28d15d7f8ebcb352f48f3295057cfb22)","restricted_domain":"example.com,example.org","trigger_login_automatically":true,"idp_metadata_xml":"metadata_xml","jit_enabled":true,"disable_email_password_login":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 65.665084ms
+        duration: 65.757625ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -402,13 +402,13 @@ interactions:
         trailer: {}
         content_length: 757
         uncompressed: false
-        body: '{"success":true,"data":{"config_type":"saml","saml_first_name_attribute":"first_name","saml_last_name_attribute":"last_name","saml_groups_attribute":"groups","saml_sync_group_claims":true,"ldap_sync_group_claims":true,"ldap_role_mapping":"admin->admin_group,user->user_group,user->another_user_group","ldap_server_url":"ldap://example.com","ldap_base_domain_components":"dc=example,dc=com","ldap_server_name":"ldap.example.com","ldap_server_key":"__RETOOL_ENCRYPTED__(7a08f5924114b5646723610a16e7710d)","ldap_server_certificate":"__RETOOL_ENCRYPTED__(28d15d7f8ebcb352f48f3295057cfb22)","restricted_domain":"example.com,example.org","trigger_login_automatically":true,"idp_metadata_xml":"metadata_xml","jit_enabled":true,"disable_email_password_login":true}}'
+        body: '{"success":true,"data":{"config_type":"saml","saml_first_name_attribute":"first_name","saml_last_name_attribute":"last_name","saml_groups_attribute":"groups","saml_sync_group_claims":true,"ldap_sync_group_claims":true,"ldap_role_mapping":"user->user_group,user->another_user_group,admin->admin_group","ldap_server_url":"ldap://example.com","ldap_base_domain_components":"dc=example,dc=com","ldap_server_name":"ldap.example.com","ldap_server_key":"__RETOOL_ENCRYPTED__(7a08f5924114b5646723610a16e7710d)","ldap_server_certificate":"__RETOOL_ENCRYPTED__(28d15d7f8ebcb352f48f3295057cfb22)","restricted_domain":"example.com,example.org","trigger_login_automatically":true,"idp_metadata_xml":"metadata_xml","jit_enabled":true,"disable_email_password_login":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 64.130125ms
+        duration: 75.377375ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -444,7 +444,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 76.172458ms
+        duration: 70.263292ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -477,7 +477,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 66.833375ms
+        duration: 64.7885ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -510,8 +510,41 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 74.223292ms
+        duration: 69.073625ms
     - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: recorded.retool.dev
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - OpenAPI-Generator/1.0.0/go
+        url: https://recorded.retool.dev/api/v2/sso/config
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 877
+        uncompressed: false
+        body: '{"success":true,"data":{"config_type":"google & saml","saml_first_name_attribute":"first_name","saml_last_name_attribute":"last_name","saml_groups_attribute":"groups","saml_sync_group_claims":true,"ldap_sync_group_claims":true,"ldap_role_mapping":"admin->admin_group,user->user_group,user->another_user_group","ldap_server_url":"ldap://example.com","ldap_base_domain_components":"dc=example,dc=com","ldap_server_name":"ldap.example.com","ldap_server_key":"__RETOOL_ENCRYPTED__(7a08f5924114b5646723610a16e7710d)","ldap_server_certificate":"__RETOOL_ENCRYPTED__(28d15d7f8ebcb352f48f3295057cfb22)","restricted_domain":"example.com,example.org","trigger_login_automatically":true,"idp_metadata_xml":"metadata_xml","jit_enabled":true,"disable_email_password_login":true,"google_client_id":"client_id","google_client_secret":"__RETOOL_ENCRYPTED__(d2c542b01b439eb4552f7925bf8fd4e1)"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 63.560167ms
+    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -546,8 +579,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 78.884041ms
-    - id: 16
+        duration: 74.97125ms
+    - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -579,8 +612,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 69.607291ms
-    - id: 17
+        duration: 64.471125ms
+    - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -610,4 +643,4 @@ interactions:
         headers: {}
         status: 204 No Content
         code: 204
-        duration: 70.039166ms
+        duration: 65.188208ms

--- a/test/data/recordings/TestAccSourceControlSettings.yaml
+++ b/test/data/recordings/TestAccSourceControlSettings.yaml
@@ -36,7 +36,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 84.06ms
+        duration: 95.625125ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 68.8835ms
+        duration: 70.675959ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -102,8 +102,41 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 63.643209ms
+        duration: 66.962167ms
     - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: recorded.retool.dev
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - OpenAPI-Generator/1.0.0/go
+        url: https://recorded.retool.dev/api/v2/source_control/settings
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 196
+        uncompressed: false
+        body: '{"success":true,"data":{"auto_branch_naming_enabled":false,"custom_pull_request_template_enabled":true,"custom_pull_request_template":"custom-pull-request-template","version_control_locked":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 72.633458ms
+    - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -138,40 +171,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 72.890375ms
-    - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: recorded.retool.dev
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - OpenAPI-Generator/1.0.0/go
-        url: https://recorded.retool.dev/api/v2/source_control/settings
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 205
-        uncompressed: false
-        body: '{"success":true,"data":{"auto_branch_naming_enabled":true,"custom_pull_request_template_enabled":false,"custom_pull_request_template":"custom-pull-request-template-updated","version_control_locked":false}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 65.675833ms
+        duration: 75.057333ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -204,8 +204,41 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 67.390208ms
+        duration: 63.974959ms
     - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: recorded.retool.dev
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - OpenAPI-Generator/1.0.0/go
+        url: https://recorded.retool.dev/api/v2/source_control/settings
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 205
+        uncompressed: false
+        body: '{"success":true,"data":{"auto_branch_naming_enabled":true,"custom_pull_request_template_enabled":false,"custom_pull_request_template":"custom-pull-request-template-updated","version_control_locked":false}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 72.435959ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -240,8 +273,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 72.727208ms
-    - id: 7
+        duration: 73.421834ms
+    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -273,8 +306,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 64.495209ms
-    - id: 8
+        duration: 73.144916ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -309,4 +342,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 76.379208ms
+        duration: 75.02075ms

--- a/test/data/recordings/TestAccSourceControlTest.yaml
+++ b/test/data/recordings/TestAccSourceControlTest.yaml
@@ -36,7 +36,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 85.687ms
+        duration: 143.993708ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 61.137208ms
+        duration: 370.805916ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -102,7 +102,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 66.7385ms
+        duration: 319.899041ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -138,7 +138,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 71.157875ms
+        duration: 75.94375ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -171,7 +171,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 59.890291ms
+        duration: 65.163375ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -204,7 +204,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 66.875542ms
+        duration: 68.443833ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -240,7 +240,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 75.892667ms
+        duration: 79.486666ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -273,7 +273,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 82.638042ms
+        duration: 64.54075ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -306,7 +306,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 57.807208ms
+        duration: 67.293334ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -342,7 +342,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 73.462583ms
+        duration: 79.706209ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -375,7 +375,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 62.278042ms
+        duration: 81.806083ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -408,7 +408,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 61.009625ms
+        duration: 67.687458ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -444,7 +444,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 74.323292ms
+        duration: 78.268541ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -477,7 +477,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 63.040875ms
+        duration: 70.276333ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -510,7 +510,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 64.819708ms
+        duration: 73.63375ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -546,7 +546,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 74.518625ms
+        duration: 82.736125ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -579,7 +579,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 61.311458ms
+        duration: 66.537083ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -612,7 +612,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 59.920084ms
+        duration: 63.078084ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -648,7 +648,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 80.171292ms
+        duration: 78.482958ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -681,8 +681,41 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 61.546667ms
+        duration: 67.431416ms
     - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: recorded.retool.dev
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - OpenAPI-Generator/1.0.0/go
+        url: https://recorded.retool.dev/api/v2/source_control/config
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 343
+        uncompressed: false
+        body: '{"success":true,"data":{"org":"my-org-updated","repo":"my-repo-updated","default_branch":"main-updated","repo_version":"2.0.0","provider":"Azure Repos","config":{"url":"https://dev.azure.com/organization-updated","project":"project-updated","user":"user-id-updated","personal_access_token":"---encrypted-on-server---","use_basic_auth":false}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 64.626458ms
+    - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -712,4 +745,4 @@ interactions:
         headers: {}
         status: 204 No Content
         code: 204
-        duration: 81.297541ms
+        duration: 83.579459ms


### PR DESCRIPTION
### Description
At first, I didn't implement [import](https://developer.hashicorp.com/terraform/language/import) support for resources that don't have straightforward "id". But being able to import them is actually pretty useful, given that it makes it possible to use [generate configuration](https://developer.hashicorp.com/terraform/language/import/generating-configuration) function of Terraform.

This change adds `ImportState` method to resources that don't have it yet. In most cases, we don't care about import id, but for `permissions` resource we use subject to identify it.

### Tests
Updated acceptance tests and re-recorded requests.
