### PR TITLE
[fix] Ignore 404s when revoking permissions

### DIFF
--- a/internal/provider/permissions/resource.go
+++ b/internal/provider/permissions/resource.go
@@ -191,6 +191,11 @@ func (r *permissionResource) revokePermission(ctx context.Context, subject permi
 	request := api.NewPermissionsRevokePostRequest(createNewAPIPermissionsSubject(subject), createNewAPIPermissionsObject(object))
 	_, httpResponse, err := r.client.PermissionsAPI.PermissionsRevokePost(ctx).PermissionsRevokePostRequest(*request).Execute()
 	if err != nil {
+		if httpResponse != nil && httpResponse.StatusCode == 404 {
+			// If the permission does not exist, we can ignore the error.
+			tflog.Info(ctx, "Permission not found", map[string]any{"id": permissionID})
+			return diags
+		}
 		diags.AddError(
 			"Error deleting permission",
 			"Could not delete permission with ID "+permissionID+": "+err.Error(),


### PR DESCRIPTION
### Description
In some cases our provider may attempt to delete permission that doesn't exist anymore. This is normal situation and we shouldn't display an error in this case. This change updates the code to handle 404 from the API.

### Tests
`make test-acc-replay` passed.