### PR TITLE
[fix] Set default creation options when importing retool_space resource

### DIFF
--- a/internal/provider/space/resource_test.go
+++ b/internal/provider/space/resource_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/tryretool/terraform-provider-retool/internal/acctest"
 )
@@ -69,6 +70,31 @@ func TestAccSpace(t *testing.T) {
 			{
 				ResourceName: "retool_space.test_space",
 				ImportState:  true,
+				ImportStateCheck: func(state []*terraform.InstanceState) error {
+					if len(state) != 1 {
+						return fmt.Errorf("Unexpected number of objects in state %d", len(state))
+					}
+					stateObj := state[0]
+					if stateObj.Attributes["name"] != "tf-acc-test-space" {
+						return fmt.Errorf("Unexpected name %s", stateObj.Attributes["name"])
+					}
+					if stateObj.Attributes["domain"] != "tfspace.localhost" {
+						return fmt.Errorf("Unexpected domain %s", stateObj.Attributes["domain"])
+					}
+					if stateObj.Attributes["create_options.copy_sso_settings"] != "false" {
+						return fmt.Errorf("Unexpected copy_sso_settings %s", stateObj.Attributes["create_options.copy_sso_settings"])
+					}
+					if stateObj.Attributes["create_options.copy_branding_and_themes_settings"] != "false" {
+						return fmt.Errorf("Unexpected copy_branding_and_themes_settings %s", stateObj.Attributes["create_options.copy_branding_and_themes_settings"])
+					}
+					if stateObj.Attributes["create_options.create_admin_user"] != "true" {
+						return fmt.Errorf("Unexpected create_admin_user %s", stateObj.Attributes["create_options.create_admin_user"])
+					}
+					if stateObj.Attributes["create_options.users_to_copy_as_admins.#"] != "0" {
+						return fmt.Errorf("Unexpected users_to_copy_as_admins %s", stateObj.Attributes["create_options.users_to_copy_as_admins.#"])
+					}
+					return nil
+				},
 			},
 			// Update and Read.
 			{


### PR DESCRIPTION
### Description
While experimenting with auto-generated TF code, I noticed that TF _always_ wants to delete and create a space again, even when we're importing an existing space:
```
  # retool_space.dev_terraform_retool_dev must be replaced
  # (imported from "org_546e2e6bfe2945d38a063b0bd1b112c1")
  # Warning: this will destroy the imported resource
-/+ resource "retool_space" "dev_terraform_retool_dev" {
      + create_options = { # forces replacement
          + copy_branding_and_themes_settings = false
          + copy_sso_settings                 = false
          + create_admin_user                 = true
          + users_to_copy_as_admins           = []
        }
        domain         = "dev.terraform.retool.dev"
      ~ id             = "org_546e2e6bfe2945d38a063b0bd1b112c1" -> (known after apply)
        name           = "Dev Space"
    }
```
That's because `create_options` attribute is configured as `requires replace` - any change in the options would require TF to delete existing space and create a new one, to make sure it's created with the right options.

What happens during the import is:
- TF creates new resource for the space, and sets `create_options` to null.
- It then "remembers" that `create_options` has default value and sets it.
- Now it looks like `create_options` has changed, so the space must be destroyed and created again.

Long story short, this change simply sets `create_options` to default value _on import_ . 

### Tests
- Tested the import scenario with my local build of the provider, verified that it doesn't attempt to re-create the space now:
```
  # retool_space.dev_terraform_retool_dev will be imported
    resource "retool_space" "dev_terraform_retool_dev" {
        create_options = {
            copy_branding_and_themes_settings = false
            copy_sso_settings                 = false
            create_admin_user                 = true
            users_to_copy_as_admins           = []
        }
        domain         = "dev.terraform.retool.dev"
        id             = "org_546e2e6bfe2945d38a063b0bd1b112c1"
        name           = "Dev Space"
    }
```
- Updated the acceptance test to verify new behavior.