### PR TITLE
Fix false "Incompatible Retool version" error on build-hash-suffixed versions

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -119,11 +119,10 @@ type healthCheckResponse struct {
 	Version string `json:"version"`
 }
 
-// isCompatibleVersion reports whether the version string returned by
-// /api/checkHealth satisfies minimumRetoolVersion.
+// IsCompatibleVersion reports whether a checkHealth version satisfies minimumRetoolVersion.
 //
 // Retool Cloud reports a build-hash-suffixed version (e.g. "4.8.0-0838649").
-// golang.org/x/mod/semver treats "0838649" as a pre-release identifier with an
+// Golang.org/x/mod/semver treats "0838649" as a pre-release identifier with an
 // illegal leading zero, marks the entire string invalid, and semver.Compare
 // then sorts any invalid string below every valid one - producing a false
 // "Incompatible Retool version" error. The suffix is build metadata, not a

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -118,6 +119,22 @@ type healthCheckResponse struct {
 	Version string `json:"version"`
 }
 
+// isCompatibleVersion reports whether the version string returned by
+// /api/checkHealth satisfies minimumRetoolVersion.
+//
+// Retool Cloud reports a build-hash-suffixed version (e.g. "4.8.0-0838649").
+// golang.org/x/mod/semver treats "0838649" as a pre-release identifier with an
+// illegal leading zero, marks the entire string invalid, and semver.Compare
+// then sorts any invalid string below every valid one - producing a false
+// "Incompatible Retool version" error. The suffix is build metadata, not a
+// semver pre-release, so compare on the core MAJOR.MINOR.PATCH only.
+func isCompatibleVersion(version string) bool {
+	if i := strings.IndexAny(version, "-+"); i != -1 {
+		version = version[:i]
+	}
+	return semver.Compare("v"+version, minimumRetoolVersion) >= 0
+}
+
 func checkMinimalVersion(ctx context.Context, host string, scheme string, httpClient *http.Client) (bool, error) {
 	// Create HTTP client, make GET /api/checkHealth request, parse the version field out of the JSON response.
 	httpResponse, err := httpClient.Get(scheme + "://" + host + "/api/checkHealth")
@@ -148,7 +165,7 @@ func checkMinimalVersion(ctx context.Context, host string, scheme string, httpCl
 	}
 	tflog.Info(ctx, "Retool version", map[string]any{"version": healthCheck.Version})
 
-	return semver.Compare("v"+healthCheck.Version, minimumRetoolVersion) >= 0, nil
+	return isCompatibleVersion(healthCheck.Version), nil
 }
 
 // Configure prepares a Retool API client for data sources and resources.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -30,3 +30,26 @@ func TestProviderMetadata(t *testing.T) {
 
 	assert.Equal(t, "retool", resp.TypeName)
 }
+
+func TestIsCompatibleVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{"clean version above minimum", "4.8.0", true},
+		{"exact minimum", "4.0.0", true},
+		{"below minimum", "3.334.0", false},
+		// Retool Cloud 4.x reports a build-hash suffix that x/mod/semver
+		// rejects as an invalid (leading-zero) pre-release identifier.
+		{"build-hash suffix above minimum", "4.8.0-0838649", true},
+		{"build-hash suffix below minimum", "3.99.0-0838649", false},
+		{"build-metadata suffix above minimum", "4.8.0+0838649", true},
+		{"empty version", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isCompatibleVersion(tt.version))
+		})
+	}
+}


### PR DESCRIPTION
### Description

Retool Cloud reports a build-hash-suffixed version from `/api/checkHealth` (e.g. `4.8.0-0838649`). `golang.org/x/mod/semver` treats `0838649` as a pre-release identifier with an illegal leading zero, so it marks the entire version string invalid, and `semver.Compare` sorts any invalid string *below* every valid version.

The effect: `checkMinimalVersion` returns `false` for every Retool Cloud instance, so the provider fails configuration on every `plan`/`apply` with:

```
Error: Incompatible Retool version
The Retool instance version is not supported. Minimum version required is v4.0.0
```

…even though the instance (`4.8.0`) is well above the `v4.0.0` minimum. This blocks all Terraform operations against Retool Cloud, not just retool resources, since the provider can't be configured. (Reported in #66.)

The build-hash suffix is build metadata, not a semver pre-release. This strips the suffix (`-`/`+`) and compares on the core `MAJOR.MINOR.PATCH`, which is all the minimum-version gate needs.

Fixes #66.

### Tests

Added `TestIsCompatibleVersion` (table-driven, `internal/provider/provider_test.go`) covering:
- clean versions above / at / below the minimum
- the `4.8.0-0838649` build-hash case (the regression)
- build-metadata (`+`) suffixes
- empty input

Run with `FILTER=TestIsCompatibleVersion make test-unit`.